### PR TITLE
0.2.3-alpha.11 merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # RTFP_Desktop
 personal paper management system, **RTFP** means <i>read the fa_king paper</i>.
+
+![image](https://user-images.githubusercontent.com/42532325/184797285-ebd0e145-0dba-46f5-8e34-7d99cf2db898.png)
+
+![image](https://user-images.githubusercontent.com/42532325/184797358-468c3700-a2d4-41ad-9967-d2d77231e940.png)
+
+![image](https://user-images.githubusercontent.com/42532325/184797446-68666516-e0bf-4c09-8f6c-135c4fa874f6.png)
+
+![image](https://user-images.githubusercontent.com/42532325/184797465-237aacb4-e929-42c8-b8e3-e877ad3b58e0.png)
+
+![image](https://user-images.githubusercontent.com/42532325/184797676-b227371d-0663-4259-9854-1449e7459efe.png)
+
+
+
+
+
+
+

--- a/RTFP_Desktop.lpi
+++ b/RTFP_Desktop.lpi
@@ -316,7 +316,6 @@
       </Item6>
       <Item7>
         <Name Value="EDatabaseError"/>
-        <Enabled Value="False"/>
       </Item7>
       <Item8>
         <Name Value="EConvertError"/>

--- a/RTFP_Desktop.lpi
+++ b/RTFP_Desktop.lpi
@@ -101,7 +101,9 @@
       <Unit8>
         <Filename Value="forms\form_formatedit_option.pas"/>
         <IsPartOfProject Value="True"/>
+        <ComponentName Value="FormFormatEditOption"/>
         <HasResources Value="True"/>
+        <ResourceBaseClass Value="Form"/>
       </Unit8>
       <Unit9>
         <Filename Value="forms\form_import.pas"/>

--- a/RTFP_Desktop.lpi
+++ b/RTFP_Desktop.lpi
@@ -48,7 +48,7 @@
         <PackageName Value="LCL"/>
       </Item8>
     </RequiredPackages>
-    <Units Count="46">
+    <Units Count="47">
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -269,6 +269,10 @@
         <Filename Value="rtfp_core\update.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit45>
+      <Unit46>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit46>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/RTFP_Desktop.lpr
+++ b/RTFP_Desktop.lpr
@@ -12,7 +12,7 @@ uses
   tachartlazaruspkg, form_classmanager, form_appearance, form_options,
   form_report_tool, form_repeated_checker, form_project_profile,
   form_field_display_option, form_formatedit_option,
-  source_dialog, sync_timer, rtfp_type, form_field_change;
+  source_dialog, sync_timer, rtfp_type, rtfp_dataset_sorter, form_field_change;
 
 {$R *.res}
 

--- a/RTFP_Desktop.lps
+++ b/RTFP_Desktop.lps
@@ -4,13 +4,13 @@
     <PathDelim Value="\"/>
     <Version Value="10"/>
     <BuildModes Active="Default"/>
-    <Units Count="125">
+    <Units Count="129">
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
-        <CursorPos X="51" Y="22"/>
+        <CursorPos X="39" Y="26"/>
         <UsageCount Value="201"/>
       </Unit0>
       <Unit1>
@@ -21,8 +21,8 @@
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="RTFP_main"/>
         <IsVisibleTab Value="True"/>
-        <TopLine Value="2268"/>
-        <CursorPos X="5" Y="2288"/>
+        <TopLine Value="2243"/>
+        <CursorPos X="3" Y="2265"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -33,7 +33,7 @@
         <ComponentName Value="Form_FileSource"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="34"/>
+        <EditorIndex Value="35"/>
         <TopLine Value="73"/>
         <CursorPos X="16" Y="87"/>
         <UsageCount Value="202"/>
@@ -43,7 +43,7 @@
       <Unit3>
         <Filename Value="sync\sync_timer.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="35"/>
+        <EditorIndex Value="36"/>
         <TopLine Value="7"/>
         <CursorPos X="16" Y="25"/>
         <UsageCount Value="200"/>
@@ -65,7 +65,7 @@
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="24"/>
+        <EditorIndex Value="25"/>
         <TopLine Value="136"/>
         <CursorPos X="13" Y="150"/>
         <UsageCount Value="201"/>
@@ -78,7 +78,7 @@
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="33"/>
+        <EditorIndex Value="34"/>
         <TopLine Value="177"/>
         <CursorPos X="22" Y="192"/>
         <UsageCount Value="201"/>
@@ -91,7 +91,7 @@
         <ComponentName Value="FormFieldDisplayOption"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="11"/>
+        <EditorIndex Value="10"/>
         <TopLine Value="40"/>
         <CursorPos X="10" Y="68"/>
         <UsageCount Value="201"/>
@@ -123,7 +123,7 @@
         <ComponentName Value="Form_NewProject"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="14"/>
+        <EditorIndex Value="13"/>
         <TopLine Value="20"/>
         <CursorPos X="79" Y="31"/>
         <UsageCount Value="201"/>
@@ -136,7 +136,7 @@
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="28"/>
+        <EditorIndex Value="29"/>
         <TopLine Value="179"/>
         <CursorPos X="24" Y="191"/>
         <UsageCount Value="201"/>
@@ -167,7 +167,7 @@
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="32"/>
+        <EditorIndex Value="33"/>
         <TopLine Value="432"/>
         <CursorPos X="33" Y="452"/>
         <UsageCount Value="201"/>
@@ -177,7 +177,7 @@
       <Unit15>
         <Filename Value="rtfp_core\rtfp_class.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="27"/>
+        <EditorIndex Value="28"/>
         <TopLine Value="101"/>
         <CursorPos X="7" Y="201"/>
         <UsageCount Value="201"/>
@@ -186,7 +186,7 @@
       <Unit16>
         <Filename Value="rtfp_core\rtfp_constants.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="30"/>
+        <EditorIndex Value="31"/>
         <CursorPos X="43" Y="42"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -195,16 +195,16 @@
         <Filename Value="rtfp_core\rtfp_definition.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="RTFP_definition"/>
-        <EditorIndex Value="18"/>
-        <TopLine Value="279"/>
-        <CursorPos X="3" Y="93"/>
+        <EditorIndex Value="17"/>
+        <TopLine Value="354"/>
+        <CursorPos X="39" Y="376"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit17>
       <Unit18>
         <Filename Value="rtfp_core\rtfp_dialog.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="36"/>
+        <EditorIndex Value="37"/>
         <TopLine Value="307"/>
         <CursorPos Y="127"/>
         <UsageCount Value="201"/>
@@ -213,7 +213,7 @@
       <Unit19>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="15"/>
+        <EditorIndex Value="14"/>
         <TopLine Value="46"/>
         <CursorPos X="57" Y="63"/>
         <UsageCount Value="201"/>
@@ -222,14 +222,14 @@
       <Unit20>
         <Filename Value="rtfp_core\rtfp_files.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="23"/>
+        <EditorIndex Value="24"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit20>
       <Unit21>
         <Filename Value="rtfp_core\rtfp_format_component.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="31"/>
+        <EditorIndex Value="32"/>
         <CursorPos X="33" Y="29"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -237,7 +237,7 @@
       <Unit22>
         <Filename Value="rtfp_core\rtfp_misc.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="25"/>
+        <EditorIndex Value="26"/>
         <TopLine Value="67"/>
         <CursorPos Y="28"/>
         <UsageCount Value="201"/>
@@ -255,15 +255,14 @@
       <Unit24>
         <Filename Value="rtfp_core\rtfp_type.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="26"/>
-        <CursorPos X="46" Y="13"/>
+        <EditorIndex Value="27"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit24>
       <Unit25>
         <Filename Value="rtfp_pdf\rtfp_pdfium.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="17"/>
+        <EditorIndex Value="16"/>
         <TopLine Value="108"/>
         <CursorPos X="29" Y="135"/>
         <UsageCount Value="200"/>
@@ -272,7 +271,7 @@
       <Unit26>
         <Filename Value="rtfp_pdf\rtfp_pdfobj.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="16"/>
+        <EditorIndex Value="15"/>
         <TopLine Value="165"/>
         <CursorPos X="32" Y="173"/>
         <UsageCount Value="200"/>
@@ -302,20 +301,20 @@
         <ComponentName Value="Form_FieldChange"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="12"/>
+        <EditorIndex Value="11"/>
         <TopLine Value="94"/>
-        <CursorPos X="3" Y="99"/>
-        <UsageCount Value="179"/>
+        <CursorPos X="37" Y="117"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit29>
       <Unit30>
         <Filename Value="rtfp_core\rtfp_field_convert.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="13"/>
+        <EditorIndex Value="12"/>
         <TopLine Value="79"/>
         <CursorPos X="40" Y="55"/>
-        <UsageCount Value="167"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit30>
       <Unit31>
@@ -324,24 +323,24 @@
         <EditorIndex Value="4"/>
         <TopLine Value="79"/>
         <CursorPos X="53" Y="100"/>
-        <UsageCount Value="178"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit31>
       <Unit32>
         <Filename Value="rtfp_core\access_field.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="21"/>
+        <EditorIndex Value="22"/>
         <CursorPos X="34" Y="11"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit32>
       <Unit33>
         <Filename Value="rtfp_core\control_interface.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="22"/>
-        <TopLine Value="322"/>
-        <CursorPos X="62" Y="341"/>
-        <UsageCount Value="177"/>
+        <EditorIndex Value="23"/>
+        <TopLine Value="524"/>
+        <CursorPos X="5" Y="507"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit33>
       <Unit34>
@@ -350,7 +349,7 @@
         <EditorIndex Value="6"/>
         <TopLine Value="207"/>
         <CursorPos X="63" Y="235"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit34>
       <Unit35>
@@ -359,40 +358,40 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="393"/>
         <CursorPos X="39" Y="415"/>
-        <UsageCount Value="171"/>
+        <UsageCount Value="203"/>
       </Unit35>
       <Unit36>
         <Filename Value="rtfp_core\aufunc.inc"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="7"/>
-        <TopLine Value="423"/>
-        <CursorPos X="28" Y="439"/>
-        <UsageCount Value="163"/>
+        <TopLine Value="656"/>
+        <CursorPos X="49" Y="676"/>
+        <UsageCount Value="204"/>
         <Loaded Value="True"/>
       </Unit36>
       <Unit37>
         <Filename Value="rtfp_core\access_base.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="10"/>
+        <EditorIndex Value="9"/>
         <TopLine Value="256"/>
         <CursorPos X="27" Y="300"/>
-        <UsageCount Value="152"/>
+        <UsageCount Value="209"/>
         <Loaded Value="True"/>
       </Unit37>
       <Unit38>
         <Filename Value="rtfp_core\events.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="20"/>
-        <CursorPos X="23" Y="20"/>
-        <UsageCount Value="148"/>
+        <EditorIndex Value="21"/>
+        <CursorPos X="66" Y="17"/>
+        <UsageCount Value="205"/>
         <Loaded Value="True"/>
       </Unit38>
       <Unit39>
         <Filename Value="rtfp_core\access_attrs.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="29"/>
+        <EditorIndex Value="30"/>
         <CursorPos X="27" Y="16"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit39>
       <Unit40>
@@ -402,7 +401,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
       </Unit40>
       <Unit41>
         <Filename Value="rtfp_core\image.inc"/>
@@ -411,7 +410,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
       </Unit41>
       <Unit42>
         <Filename Value="rtfp_core\notes.inc"/>
@@ -420,15 +419,15 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
       </Unit42>
       <Unit43>
         <Filename Value="rtfp_core\paper.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="19"/>
+        <EditorIndex Value="18"/>
         <TopLine Value="458"/>
         <CursorPos X="16" Y="464"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit43>
       <Unit44>
@@ -438,7 +437,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
       </Unit44>
       <Unit45>
         <Filename Value="rtfp_core\update.inc"/>
@@ -447,108 +446,117 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="136"/>
+        <UsageCount Value="200"/>
       </Unit45>
       <Unit46>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <IsPartOfProject Value="True"/>
+        <EditorIndex Value="19"/>
+        <TopLine Value="260"/>
+        <CursorPos X="56" Y="220"/>
+        <UsageCount Value="69"/>
+        <Loaded Value="True"/>
+      </Unit46>
+      <Unit47>
         <Filename Value="..\FPC_Unit\Auf\aufscript_frame.pas"/>
         <ComponentName Value="Frame_AufScript"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Frame"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="82" Y="9"/>
-        <UsageCount Value="178"/>
-      </Unit46>
-      <Unit47>
+        <UsageCount Value="171"/>
+      </Unit47>
+      <Unit48>
         <Filename Value="..\FPC_Unit\Auf\synhighlighterauf.pas"/>
         <UnitName Value="SynHighlighterAuf"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="13"/>
-      </Unit47>
-      <Unit48>
+        <UsageCount Value="6"/>
+      </Unit48>
+      <Unit49>
         <Filename Value="rtfp_pdfium.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="164"/>
         <CursorPos X="60" Y="191"/>
-        <UsageCount Value="184"/>
-      </Unit48>
-      <Unit49>
+        <UsageCount Value="177"/>
+      </Unit49>
+      <Unit50>
         <Filename Value="rtfp_pdfobj.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="217"/>
         <CursorPos X="73" Y="217"/>
-        <UsageCount Value="182"/>
-      </Unit49>
-      <Unit50>
+        <UsageCount Value="175"/>
+      </Unit50>
+      <Unit51>
         <Filename Value="rtfp_definition.pas"/>
         <UnitName Value="RTFP_definition"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="230"/>
         <CursorPos X="14" Y="242"/>
-        <UsageCount Value="183"/>
-      </Unit50>
-      <Unit51>
+        <UsageCount Value="176"/>
+      </Unit51>
+      <Unit52>
         <Filename Value="rtfp_field.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="76"/>
         <CursorPos X="15" Y="90"/>
-        <UsageCount Value="188"/>
-      </Unit51>
-      <Unit52>
+        <UsageCount Value="181"/>
+      </Unit52>
+      <Unit53>
         <Filename Value="rtfp_class.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
         <CursorPos X="15" Y="17"/>
-        <UsageCount Value="184"/>
-      </Unit52>
-      <Unit53>
+        <UsageCount Value="177"/>
+      </Unit53>
+      <Unit54>
         <Filename Value="rtfp_files.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="74"/>
         <CursorPos X="45" Y="77"/>
-        <UsageCount Value="183"/>
-      </Unit53>
-      <Unit54>
+        <UsageCount Value="176"/>
+      </Unit54>
+      <Unit55>
         <Filename Value="rtfp_constants.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="42" Y="15"/>
-        <UsageCount Value="184"/>
-      </Unit54>
-      <Unit55>
+        <UsageCount Value="177"/>
+      </Unit55>
+      <Unit56>
         <Filename Value="rtfp_format_component.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="503"/>
         <CursorPos X="48" Y="506"/>
-        <UsageCount Value="183"/>
-      </Unit55>
-      <Unit56>
+        <UsageCount Value="176"/>
+      </Unit56>
+      <Unit57>
         <Filename Value="rtfp_tags.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="46" Y="155"/>
-        <UsageCount Value="182"/>
-      </Unit56>
-      <Unit57>
+        <UsageCount Value="175"/>
+      </Unit57>
+      <Unit58>
         <Filename Value="rtfp_misc.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="20" Y="33"/>
-        <UsageCount Value="182"/>
-      </Unit57>
-      <Unit58>
+        <UsageCount Value="175"/>
+      </Unit58>
+      <Unit59>
         <Filename Value="rtfp_dialog.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="43" Y="40"/>
-        <UsageCount Value="184"/>
-      </Unit58>
-      <Unit59>
+        <UsageCount Value="177"/>
+      </Unit59>
+      <Unit60>
         <Filename Value="rtfp_type.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6"/>
         <CursorPos X="30" Y="28"/>
-        <UsageCount Value="184"/>
-      </Unit59>
-      <Unit60>
+        <UsageCount Value="177"/>
+      </Unit60>
+      <Unit61>
         <Filename Value="form_new_project.pas"/>
         <ComponentName Value="Form_NewProject"/>
         <HasResources Value="True"/>
@@ -556,9 +564,9 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="91"/>
         <CursorPos X="54" Y="108"/>
-        <UsageCount Value="182"/>
-      </Unit60>
-      <Unit61>
+        <UsageCount Value="175"/>
+      </Unit61>
+      <Unit62>
         <Filename Value="form_cite_trans.pas"/>
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
@@ -566,9 +574,9 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="35"/>
         <CursorPos X="90" Y="39"/>
-        <UsageCount Value="182"/>
-      </Unit61>
-      <Unit62>
+        <UsageCount Value="175"/>
+      </Unit62>
+      <Unit63>
         <Filename Value="form_import.pas"/>
         <ComponentName Value="Form_ImportFiles"/>
         <HasResources Value="True"/>
@@ -576,9 +584,9 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="264"/>
         <CursorPos X="96" Y="265"/>
-        <UsageCount Value="189"/>
-      </Unit62>
-      <Unit63>
+        <UsageCount Value="182"/>
+      </Unit63>
+      <Unit64>
         <Filename Value="form_classmanager.pas"/>
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
@@ -586,18 +594,18 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="81" Y="27"/>
-        <UsageCount Value="183"/>
-      </Unit63>
-      <Unit64>
+        <UsageCount Value="176"/>
+      </Unit64>
+      <Unit65>
         <Filename Value="form_appearance.pas"/>
         <ComponentName Value="AppearanceForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="102" Y="3"/>
-        <UsageCount Value="183"/>
-      </Unit64>
-      <Unit65>
+        <UsageCount Value="176"/>
+      </Unit65>
+      <Unit66>
         <Filename Value="form_options.pas"/>
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
@@ -605,9 +613,9 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="41"/>
         <CursorPos X="42" Y="43"/>
-        <UsageCount Value="185"/>
-      </Unit65>
-      <Unit66>
+        <UsageCount Value="178"/>
+      </Unit66>
+      <Unit67>
         <Filename Value="form_report_tool.pas"/>
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
@@ -615,9 +623,9 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="20"/>
         <CursorPos X="74" Y="22"/>
-        <UsageCount Value="182"/>
-      </Unit66>
-      <Unit67>
+        <UsageCount Value="175"/>
+      </Unit67>
+      <Unit68>
         <Filename Value="form_repeated_checker.pas"/>
         <ComponentName Value="FormRepeatedChecker"/>
         <HasResources Value="True"/>
@@ -625,18 +633,18 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="291"/>
         <CursorPos X="46" Y="292"/>
-        <UsageCount Value="182"/>
-      </Unit67>
-      <Unit68>
+        <UsageCount Value="175"/>
+      </Unit68>
+      <Unit69>
         <Filename Value="form_project_profile.pas"/>
         <ComponentName Value="FormProjectProfile"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="55" Y="4"/>
-        <UsageCount Value="183"/>
-      </Unit68>
-      <Unit69>
+        <UsageCount Value="176"/>
+      </Unit69>
+      <Unit70>
         <Filename Value="form_field_display_option.pas"/>
         <ComponentName Value="FormFieldDisplayOption"/>
         <HasResources Value="True"/>
@@ -644,9 +652,9 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="46"/>
         <CursorPos X="65" Y="49"/>
-        <UsageCount Value="182"/>
-      </Unit69>
-      <Unit70>
+        <UsageCount Value="175"/>
+      </Unit70>
+      <Unit71>
         <Filename Value="form_formatedit_option.pas"/>
         <ComponentName Value="FormFormatEditOption"/>
         <HasResources Value="True"/>
@@ -654,526 +662,545 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="130"/>
         <CursorPos X="15" Y="121"/>
-        <UsageCount Value="185"/>
-      </Unit70>
-      <Unit71>
+        <UsageCount Value="178"/>
+      </Unit71>
+      <Unit72>
         <Filename Value="..\AufScript\aufscript_frame.pas"/>
         <ComponentName Value="Frame_AufScript"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Frame"/>
-        <EditorIndex Value="9"/>
+        <EditorIndex Value="8"/>
         <TopLine Value="53"/>
         <CursorPos X="22" Y="67"/>
         <UsageCount Value="185"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit71>
-      <Unit72>
-        <Filename Value="..\AufScript\apiglio_useful.pas"/>
-        <UnitName Value="Apiglio_Useful"/>
-        <EditorIndex Value="8"/>
-        <TopLine Value="4585"/>
-        <CursorPos X="3" Y="4616"/>
-        <UsageCount Value="185"/>
-        <Loaded Value="True"/>
       </Unit72>
       <Unit73>
+        <Filename Value="..\AufScript\apiglio_useful.pas"/>
+        <UnitName Value="Apiglio_Useful"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="3540"/>
+        <CursorPos Y="3558"/>
+        <UsageCount Value="180"/>
+      </Unit73>
+      <Unit74>
         <Filename Value="..\AufScript\auf_ram_var.pas"/>
         <EditorIndex Value="-1"/>
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="182"/>
-      </Unit73>
-      <Unit74>
+        <UsageCount Value="175"/>
+      </Unit74>
+      <Unit75>
         <Filename Value="..\FPC_Unit\Auf\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="168"/>
-      </Unit74>
-      <Unit75>
+        <UsageCount Value="161"/>
+      </Unit75>
+      <Unit76>
         <Filename Value="..\FPC_Unit\ACL\ListViewEx\acl_listview.pas"/>
         <UnitName Value="ACL_ListView"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="34"/>
         <CursorPos Y="66"/>
-        <UsageCount Value="67"/>
-      </Unit75>
-      <Unit76>
+        <UsageCount Value="60"/>
+      </Unit76>
+      <Unit77>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\systemh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1119"/>
         <CursorPos X="11" Y="1136"/>
-        <UsageCount Value="2"/>
-      </Unit76>
-      <Unit77>
+        <UsageCount Value="5"/>
+      </Unit77>
+      <Unit78>
         <Filename Value="D:\Lazarus\lcl\stdctrls.pp"/>
         <UnitName Value="StdCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="483"/>
         <CursorPos X="3" Y="497"/>
-        <UsageCount Value="2"/>
-      </Unit77>
-      <Unit78>
-        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="479"/>
-        <CursorPos X="17" Y="497"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="5"/>
       </Unit78>
       <Unit79>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="178"/>
+        <CursorPos X="3" Y="197"/>
+        <UsageCount Value="5"/>
+      </Unit79>
+      <Unit80>
         <Filename Value="C:\lazarus\lcl\include\picture.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="560"/>
         <CursorPos X="11" Y="577"/>
-        <UsageCount Value="4"/>
-      </Unit79>
-      <Unit80>
-        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="1924"/>
-        <CursorPos X="3" Y="1942"/>
         <UsageCount Value="7"/>
       </Unit80>
       <Unit81>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="1636"/>
+        <CursorPos X="26" Y="1660"/>
+        <UsageCount Value="8"/>
+      </Unit81>
+      <Unit82>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\bufdataset.pas"/>
         <UnitName Value="BufDataset"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="582"/>
         <CursorPos X="29" Y="612"/>
-        <UsageCount Value="6"/>
-      </Unit81>
-      <Unit82>
+        <UsageCount Value="9"/>
+      </Unit82>
+      <Unit83>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="485"/>
         <CursorPos X="17" Y="497"/>
-        <UsageCount Value="8"/>
-      </Unit82>
-      <Unit83>
+        <UsageCount Value="1"/>
+      </Unit83>
+      <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\ascdef.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="102"/>
         <CursorPos X="10" Y="122"/>
-        <UsageCount Value="2"/>
-      </Unit83>
-      <Unit84>
+        <UsageCount Value="5"/>
+      </Unit84>
+      <Unit85>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win64\system.pp"/>
         <UnitName Value="System"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="121"/>
         <CursorPos Y="16"/>
-        <UsageCount Value="2"/>
-      </Unit84>
-      <Unit85>
+        <UsageCount Value="5"/>
+      </Unit85>
+      <Unit86>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\system.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="73"/>
         <CursorPos X="34" Y="10"/>
-        <UsageCount Value="2"/>
-      </Unit85>
-      <Unit86>
+        <UsageCount Value="5"/>
+      </Unit86>
+      <Unit87>
         <Filename Value="data_access.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="449"/>
         <CursorPos X="3" Y="32"/>
-        <UsageCount Value="2"/>
-      </Unit86>
-      <Unit87>
+        <UsageCount Value="5"/>
+      </Unit87>
+      <Unit88>
         <Filename Value="formatedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="141"/>
         <CursorPos X="68" Y="263"/>
-        <UsageCount Value="2"/>
-      </Unit87>
-      <Unit88>
+        <UsageCount Value="5"/>
+      </Unit88>
+      <Unit89>
         <Filename Value="papers.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="54" Y="4"/>
-        <UsageCount Value="2"/>
-      </Unit88>
-      <Unit89>
+        <UsageCount Value="5"/>
+      </Unit89>
+      <Unit90>
         <Filename Value="events.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21" Y="10"/>
-        <UsageCount Value="2"/>
-      </Unit89>
-      <Unit90>
+        <UsageCount Value="5"/>
+      </Unit90>
+      <Unit91>
         <Filename Value="tags.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="32" Y="10"/>
-        <UsageCount Value="2"/>
-      </Unit90>
-      <Unit91>
+        <UsageCount Value="5"/>
+      </Unit91>
+      <Unit92>
         <Filename Value="paper.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="5" Y="3"/>
-        <UsageCount Value="2"/>
-      </Unit91>
-      <Unit92>
+        <UsageCount Value="5"/>
+      </Unit92>
+      <Unit93>
         <Filename Value="cite_tool.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="667"/>
         <CursorPos X="40" Y="679"/>
-        <UsageCount Value="4"/>
-      </Unit92>
-      <Unit93>
-        <Filename Value="forms\form_classmanager.lfm"/>
-        <EditorIndex Value="-1"/>
-        <UsageCount Value="2"/>
-        <DefaultSyntaxHighlighter Value="LFM"/>
+        <UsageCount Value="7"/>
       </Unit93>
       <Unit94>
+        <Filename Value="forms\form_classmanager.lfm"/>
+        <EditorIndex Value="-1"/>
+        <UsageCount Value="5"/>
+        <DefaultSyntaxHighlighter Value="LFM"/>
+      </Unit94>
+      <Unit95>
         <Filename Value="D:\Lazarus\components\synedit\synhighlighterunixshellscript.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="70"/>
         <CursorPos X="25" Y="73"/>
-        <UsageCount Value="2"/>
-      </Unit94>
-      <Unit95>
+        <UsageCount Value="5"/>
+      </Unit95>
+      <Unit96>
         <Filename Value="C:\lazarus\lcl\dbgrids.pas"/>
         <UnitName Value="DBGrids"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="535"/>
         <CursorPos X="25" Y="563"/>
-        <UsageCount Value="2"/>
-      </Unit95>
-      <Unit96>
+        <UsageCount Value="5"/>
+      </Unit96>
+      <Unit97>
         <Filename Value="C:\lazarus\lcl\include\customedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="81"/>
         <CursorPos Y="100"/>
-        <UsageCount Value="8"/>
-      </Unit96>
-      <Unit97>
+        <UsageCount Value="1"/>
+      </Unit97>
+      <Unit98>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\fields.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="38"/>
         <CursorPos Y="42"/>
-        <UsageCount Value="8"/>
-      </Unit97>
-      <Unit98>
+        <UsageCount Value="1"/>
+      </Unit98>
+      <Unit99>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\registry.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="79"/>
         <CursorPos X="25" Y="104"/>
-        <UsageCount Value="4"/>
-      </Unit98>
-      <Unit99>
+        <UsageCount Value="7"/>
+      </Unit99>
+      <Unit100>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\winreg.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="167"/>
         <CursorPos X="3" Y="172"/>
-        <UsageCount Value="4"/>
-      </Unit99>
-      <Unit100>
-        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\win\wininc\func.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="931"/>
-        <CursorPos X="10" Y="949"/>
-        <UsageCount Value="1"/>
+        <UsageCount Value="7"/>
       </Unit100>
       <Unit101>
-        <Filename Value="C:\lazarus\lcl\include\customform.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="2935"/>
-        <CursorPos Y="2962"/>
-        <UsageCount Value="1"/>
-      </Unit101>
-      <Unit102>
         <Filename Value="C:\lazarus\lcl\forms.pp"/>
         <UnitName Value="Forms"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="768"/>
         <CursorPos X="14" Y="784"/>
-        <UsageCount Value="10"/>
-      </Unit102>
-      <Unit103>
+        <UsageCount Value="3"/>
+      </Unit101>
+      <Unit102>
         <Filename Value="C:\lazarus\lcl\include\control.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2236"/>
         <CursorPos Y="2253"/>
-        <UsageCount Value="7"/>
-      </Unit103>
-      <Unit104>
+        <UsageCount Value="10"/>
+      </Unit102>
+      <Unit103>
         <Filename Value="C:\lazarus\lcl\include\wincontrol.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="5381"/>
         <CursorPos Y="5398"/>
-        <UsageCount Value="7"/>
-      </Unit104>
-      <Unit105>
+        <UsageCount Value="10"/>
+      </Unit103>
+      <Unit104>
         <Filename Value="C:\lazarus\lcl\include\fpimagebitmap.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="123"/>
         <CursorPos Y="141"/>
-        <UsageCount Value="8"/>
-      </Unit105>
-      <Unit106>
+        <UsageCount Value="1"/>
+      </Unit104>
+      <Unit105>
         <Filename Value="C:\lazarus\lcl\extctrls.pp"/>
         <UnitName Value="ExtCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1035"/>
         <CursorPos X="17" Y="1053"/>
-        <UsageCount Value="9"/>
-      </Unit106>
-      <Unit107>
+        <UsageCount Value="2"/>
+      </Unit105>
+      <Unit106>
         <Filename Value="C:\lazarus\lcl\graphics.pp"/>
         <UnitName Value="Graphics"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="679"/>
         <CursorPos X="3" Y="698"/>
-        <UsageCount Value="12"/>
-      </Unit107>
-      <Unit108>
+        <UsageCount Value="5"/>
+      </Unit106>
+      <Unit107>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\regexpr\src\regexpr.pas"/>
         <UnitName Value="RegExpr"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="416"/>
         <CursorPos X="33" Y="298"/>
-        <UsageCount Value="4"/>
-      </Unit108>
-      <Unit109>
+        <UsageCount Value="7"/>
+      </Unit107>
+      <Unit108>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysunih.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="19"/>
         <CursorPos X="10" Y="48"/>
-        <UsageCount Value="8"/>
-      </Unit109>
-      <Unit110>
+        <UsageCount Value="1"/>
+      </Unit108>
+      <Unit109>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-image\src\fpcanvas.pp"/>
         <UnitName Value="FPCanvas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="36" Y="158"/>
-        <UsageCount Value="4"/>
-      </Unit110>
-      <Unit111>
+        <UsageCount Value="7"/>
+      </Unit109>
+      <Unit110>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\memds\memds.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="127"/>
         <CursorPos X="74" Y="154"/>
-        <UsageCount Value="6"/>
-      </Unit111>
-      <Unit112>
+        <UsageCount Value="9"/>
+      </Unit110>
+      <Unit111>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysuni.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="267"/>
         <CursorPos X="5" Y="277"/>
-        <UsageCount Value="7"/>
-      </Unit112>
-      <Unit113>
+        <UsageCount Value="10"/>
+      </Unit111>
+      <Unit112>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\lists.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="297"/>
-        <CursorPos Y="306"/>
-        <UsageCount Value="7"/>
-      </Unit113>
-      <Unit114>
+        <TopLine Value="773"/>
+        <CursorPos Y="775"/>
+        <UsageCount Value="5"/>
+      </Unit112>
+      <Unit113>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\sqldb\sqldb.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="576"/>
         <CursorPos X="14" Y="593"/>
-        <UsageCount Value="7"/>
-      </Unit114>
-      <Unit115>
+        <UsageCount Value="10"/>
+      </Unit113>
+      <Unit114>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\database.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="21"/>
         <CursorPos Y="21"/>
-        <UsageCount Value="8"/>
-      </Unit115>
-      <Unit116>
+        <UsageCount Value="1"/>
+      </Unit114>
+      <Unit115>
         <Filename Value="C:\lazarus\lcl\stdctrls.pp"/>
         <UnitName Value="StdCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="704"/>
         <CursorPos X="30" Y="727"/>
-        <UsageCount Value="7"/>
-      </Unit116>
-      <Unit117>
+        <UsageCount Value="10"/>
+      </Unit115>
+      <Unit116>
         <Filename Value="C:\lazarus\lcl\controls.pp"/>
         <UnitName Value="Controls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="206"/>
         <CursorPos X="3" Y="224"/>
-        <UsageCount Value="10"/>
-      </Unit117>
-      <Unit118>
+        <UsageCount Value="3"/>
+      </Unit116>
+      <Unit117>
         <Filename Value="C:\lazarus\lcl\lclclasses.pp"/>
         <UnitName Value="LCLClasses"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="24"/>
         <CursorPos X="3" Y="42"/>
-        <UsageCount Value="7"/>
-      </Unit118>
-      <Unit119>
+        <UsageCount Value="10"/>
+      </Unit117>
+      <Unit118>
         <Filename Value="..\ACL_ListView\acl_listview.pas"/>
         <UnitName Value="ACL_ListView"/>
         <EditorIndex Value="1"/>
         <TopLine Value="20"/>
         <CursorPos X="17" Y="30"/>
-        <UsageCount Value="12"/>
+        <UsageCount Value="45"/>
         <Loaded Value="True"/>
-      </Unit119>
-      <Unit120>
+      </Unit118>
+      <Unit119>
         <Filename Value="C:\lazarus\lcl\lclmessageglue.pas"/>
         <UnitName Value="LCLMessageGlue"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="95"/>
         <CursorPos Y="112"/>
-        <UsageCount Value="7"/>
-      </Unit120>
-      <Unit121>
+        <UsageCount Value="10"/>
+      </Unit119>
+      <Unit120>
         <Filename Value="C:\lazarus\lcl\interfaces\win32\win32callback.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2652"/>
         <CursorPos Y="2671"/>
-        <UsageCount Value="7"/>
-      </Unit121>
-      <Unit122>
+        <UsageCount Value="10"/>
+      </Unit120>
+      <Unit121>
         <Filename Value="C:\lazarus\lcl\include\customlistview.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1350"/>
         <CursorPos Y="1385"/>
-        <UsageCount Value="11"/>
-      </Unit122>
-      <Unit123>
+        <UsageCount Value="4"/>
+      </Unit121>
+      <Unit122>
         <Filename Value="C:\lazarus\lcl\include\listitems.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos Y="27"/>
-        <UsageCount Value="11"/>
-      </Unit123>
-      <Unit124>
+        <UsageCount Value="4"/>
+      </Unit122>
+      <Unit123>
         <Filename Value="C:\lazarus\lcl\comctrls.pp"/>
         <UnitName Value="ComCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="974"/>
         <CursorPos X="3" Y="992"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="3"/>
+      </Unit123>
+      <Unit124>
+        <Filename Value="rtfp_core\rtfp_db_sorter.pas"/>
+        <EditorIndex Value="-1"/>
+        <CursorPos X="13"/>
+        <UsageCount Value="15"/>
       </Unit124>
+      <Unit125>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysutilh.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="302"/>
+        <CursorPos X="13" Y="320"/>
+        <UsageCount Value="6"/>
+      </Unit125>
+      <Unit126>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysutils.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="154"/>
+        <CursorPos X="9" Y="158"/>
+        <UsageCount Value="5"/>
+      </Unit126>
+      <Unit127>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\inc\objpash.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="176"/>
+        <CursorPos X="23" Y="194"/>
+        <UsageCount Value="5"/>
+      </Unit127>
+      <Unit128>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\dataset.inc"/>
+        <EditorIndex Value="20"/>
+        <TopLine Value="2001"/>
+        <CursorPos X="3" Y="2017"/>
+        <UsageCount Value="20"/>
+        <Loaded Value="True"/>
+      </Unit128>
     </Units>
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="346" Column="31" TopLine="328"/>
+        <Caret Line="1705" Column="3" TopLine="1696"/>
       </Position1>
       <Position2>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2375" Column="62" TopLine="2357"/>
+        <Caret Line="1707" Column="3" TopLine="1698"/>
       </Position2>
       <Position3>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2284" Column="21" TopLine="2268"/>
+        <Caret Line="2256" Column="3" TopLine="2254"/>
       </Position3>
       <Position4>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2292" Column="16" TopLine="2277"/>
+        <Caret Line="2245" TopLine="2234"/>
       </Position4>
       <Position5>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2287" Column="4" TopLine="2277"/>
+        <Caret Line="2261" Column="24" TopLine="2243"/>
       </Position5>
       <Position6>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2285" Column="39" TopLine="2255"/>
+        <Caret Line="2286" Column="3" TopLine="2284"/>
       </Position6>
       <Position7>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2372" Column="15" TopLine="2301"/>
+        <Caret Line="2301" TopLine="2299"/>
       </Position7>
       <Position8>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2364" Column="43" TopLine="2349"/>
+        <Caret Line="2290" Column="64" TopLine="2276"/>
       </Position8>
       <Position9>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2356" Column="77" TopLine="2353"/>
+        <Caret Line="2295" Column="3" TopLine="2293"/>
       </Position9>
       <Position10>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="196" Column="26" TopLine="179"/>
+        <Caret Line="2459" TopLine="2457"/>
       </Position10>
       <Position11>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="772" Column="37" TopLine="743"/>
+        <Caret Line="2297" Column="3" TopLine="2281"/>
       </Position11>
       <Position12>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="773" Column="37" TopLine="744"/>
+        <Caret Line="2478" TopLine="2469"/>
       </Position12>
       <Position13>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="374" Column="18" TopLine="359"/>
+        <Caret Line="2307" Column="29" TopLine="2302"/>
       </Position13>
       <Position14>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="816" Column="19" TopLine="789"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="25" Column="19" TopLine="16"/>
       </Position14>
       <Position15>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2382" Column="55" TopLine="2370"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="99" Column="27" TopLine="70"/>
       </Position15>
       <Position16>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="818" Column="32" TopLine="795"/>
+        <Caret Line="2263" Column="64" TopLine="2245"/>
       </Position16>
       <Position17>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="1677" TopLine="1659"/>
+        <Caret Line="2297" Column="3" TopLine="2295"/>
       </Position17>
       <Position18>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="1694" Column="33" TopLine="1685"/>
+        <Caret Line="2264" Column="29" TopLine="2246"/>
       </Position18>
       <Position19>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="71" Column="5" TopLine="54"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="372" Column="15" TopLine="355"/>
       </Position19>
       <Position20>
-        <Filename Value="..\AufScript\aufscript_frame.pas"/>
-        <Caret Line="63" Column="19" TopLine="46"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="572" Column="12" TopLine="556"/>
       </Position20>
       <Position21>
-        <Filename Value="..\AufScript\aufscript_frame.pas"/>
-        <Caret Line="65" Column="87" TopLine="46"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="579" Column="11" TopLine="552"/>
       </Position21>
       <Position22>
-        <Filename Value="..\AufScript\aufscript_frame.pas"/>
-        <Caret Line="333" Column="49" TopLine="304"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="589" Column="11" TopLine="564"/>
       </Position22>
       <Position23>
-        <Filename Value="..\AufScript\aufscript_frame.pas"/>
-        <Caret Line="427" Column="49" TopLine="398"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="556" Column="47" TopLine="548"/>
       </Position23>
       <Position24>
-        <Filename Value="..\AufScript\aufscript_frame.pas"/>
-        <Caret Line="565" Column="19" TopLine="536"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="577" Column="57" TopLine="560"/>
       </Position24>
       <Position25>
-        <Filename Value="..\AufScript\aufscript_frame.pas"/>
-        <Caret Line="77" Column="13" TopLine="52"/>
+        <Filename Value="rtfp_core\rtfp_files.pas"/>
       </Position25>
       <Position26>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="71" Column="5" TopLine="54"/>
+        <Caret Line="2264" Column="21" TopLine="2249"/>
       </Position26>
       <Position27>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="1719" Column="34" TopLine="1699"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="372" Column="15" TopLine="354"/>
       </Position27>
       <Position28>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2376" Column="17" TopLine="2367"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="155" Column="80" TopLine="161"/>
       </Position28>
       <Position29>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2077" Column="37" TopLine="2052"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="210" Column="51" TopLine="192"/>
       </Position29>
       <Position30>
         <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2166" Column="43" TopLine="2152"/>
+        <Caret Line="2270" Column="43" TopLine="2249"/>
       </Position30>
     </JumpHistory>
   </ProjectSession>
@@ -1208,19 +1235,25 @@
         <Line Value="109"/>
       </Item4>
     </BreakPoints>
-    <Watches Count="4">
+    <Watches Count="6">
       <Item1>
-        <Expression Value="regg"/>
+        <Expression Value="order[index]"/>
       </Item1>
       <Item2>
-        <Expression Value="dbf_name_no_ext"/>
+        <Expression Value="opt.fieldName"/>
       </Item2>
       <Item3>
-        <Expression Value="Self"/>
+        <Expression Value="opt.NextOption"/>
       </Item3>
       <Item4>
-        <Expression Value="FClass.ClassName"/>
+        <Expression Value="TDataSetSortOption(opt.NextOption).fieldname"/>
       </Item4>
+      <Item5>
+        <Expression Value="TDataSetSortOption(TDataSetSortOption(opt.NextOption).NextOption)"/>
+      </Item5>
+      <Item6>
+        <Expression Value="fieldnames"/>
+      </Item6>
     </Watches>
   </Debugging>
 </CONFIG>

--- a/RTFP_Desktop.lps
+++ b/RTFP_Desktop.lps
@@ -4,14 +4,15 @@
     <PathDelim Value="\"/>
     <Version Value="10"/>
     <BuildModes Active="Default"/>
-    <Units Count="129">
+    <Units Count="124">
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="-1"/>
+        <EditorIndex Value="20"/>
         <TopLine Value="3"/>
-        <CursorPos X="39" Y="26"/>
+        <CursorPos Y="20"/>
         <UsageCount Value="201"/>
+        <Loaded Value="True"/>
       </Unit0>
       <Unit1>
         <Filename Value="rtfp_main.pas"/>
@@ -20,9 +21,7 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="RTFP_main"/>
-        <IsVisibleTab Value="True"/>
-        <TopLine Value="2243"/>
-        <CursorPos X="3" Y="2265"/>
+        <CursorPos X="18" Y="72"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -33,7 +32,7 @@
         <ComponentName Value="Form_FileSource"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="35"/>
+        <EditorIndex Value="36"/>
         <TopLine Value="73"/>
         <CursorPos X="16" Y="87"/>
         <UsageCount Value="202"/>
@@ -43,7 +42,7 @@
       <Unit3>
         <Filename Value="sync\sync_timer.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="36"/>
+        <EditorIndex Value="37"/>
         <TopLine Value="7"/>
         <CursorPos X="16" Y="25"/>
         <UsageCount Value="200"/>
@@ -65,7 +64,7 @@
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="25"/>
+        <EditorIndex Value="26"/>
         <TopLine Value="136"/>
         <CursorPos X="13" Y="150"/>
         <UsageCount Value="201"/>
@@ -78,9 +77,9 @@
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="34"/>
+        <EditorIndex Value="35"/>
         <TopLine Value="177"/>
-        <CursorPos X="22" Y="192"/>
+        <CursorPos X="28" Y="190"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -136,7 +135,7 @@
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="29"/>
+        <EditorIndex Value="30"/>
         <TopLine Value="179"/>
         <CursorPos X="24" Y="191"/>
         <UsageCount Value="201"/>
@@ -167,9 +166,9 @@
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="33"/>
-        <TopLine Value="432"/>
-        <CursorPos X="33" Y="452"/>
+        <EditorIndex Value="34"/>
+        <TopLine Value="405"/>
+        <CursorPos X="11" Y="420"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -177,7 +176,7 @@
       <Unit15>
         <Filename Value="rtfp_core\rtfp_class.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="28"/>
+        <EditorIndex Value="29"/>
         <TopLine Value="101"/>
         <CursorPos X="7" Y="201"/>
         <UsageCount Value="201"/>
@@ -186,7 +185,7 @@
       <Unit16>
         <Filename Value="rtfp_core\rtfp_constants.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="31"/>
+        <EditorIndex Value="32"/>
         <CursorPos X="43" Y="42"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -196,15 +195,15 @@
         <IsPartOfProject Value="True"/>
         <UnitName Value="RTFP_definition"/>
         <EditorIndex Value="17"/>
-        <TopLine Value="354"/>
-        <CursorPos X="39" Y="376"/>
+        <TopLine Value="37"/>
+        <CursorPos X="31" Y="23"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit17>
       <Unit18>
         <Filename Value="rtfp_core\rtfp_dialog.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="37"/>
+        <EditorIndex Value="38"/>
         <TopLine Value="307"/>
         <CursorPos Y="127"/>
         <UsageCount Value="201"/>
@@ -222,14 +221,14 @@
       <Unit20>
         <Filename Value="rtfp_core\rtfp_files.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="24"/>
+        <EditorIndex Value="25"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit20>
       <Unit21>
         <Filename Value="rtfp_core\rtfp_format_component.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="32"/>
+        <EditorIndex Value="33"/>
         <CursorPos X="33" Y="29"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -237,7 +236,7 @@
       <Unit22>
         <Filename Value="rtfp_core\rtfp_misc.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="26"/>
+        <EditorIndex Value="27"/>
         <TopLine Value="67"/>
         <CursorPos Y="28"/>
         <UsageCount Value="201"/>
@@ -255,7 +254,7 @@
       <Unit24>
         <Filename Value="rtfp_core\rtfp_type.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="27"/>
+        <EditorIndex Value="28"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit24>
@@ -329,17 +328,18 @@
       <Unit32>
         <Filename Value="rtfp_core\access_field.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="22"/>
-        <CursorPos X="34" Y="11"/>
+        <EditorIndex Value="23"/>
+        <TopLine Value="228"/>
+        <CursorPos X="39" Y="248"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit32>
       <Unit33>
         <Filename Value="rtfp_core\control_interface.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="23"/>
-        <TopLine Value="524"/>
-        <CursorPos X="5" Y="507"/>
+        <EditorIndex Value="24"/>
+        <TopLine Value="486"/>
+        <CursorPos X="27" Y="493"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit33>
@@ -381,7 +381,7 @@
       <Unit38>
         <Filename Value="rtfp_core\events.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="21"/>
+        <EditorIndex Value="22"/>
         <CursorPos X="66" Y="17"/>
         <UsageCount Value="205"/>
         <Loaded Value="True"/>
@@ -389,7 +389,7 @@
       <Unit39>
         <Filename Value="rtfp_core\access_attrs.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="30"/>
+        <EditorIndex Value="31"/>
         <CursorPos X="27" Y="16"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
@@ -451,10 +451,11 @@
       <Unit46>
         <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
         <IsPartOfProject Value="True"/>
+        <IsVisibleTab Value="True"/>
         <EditorIndex Value="19"/>
-        <TopLine Value="260"/>
-        <CursorPos X="56" Y="220"/>
-        <UsageCount Value="69"/>
+        <TopLine Value="191"/>
+        <CursorPos X="20" Y="211"/>
+        <UsageCount Value="89"/>
         <Loaded Value="True"/>
       </Unit46>
       <Unit47>
@@ -464,27 +465,27 @@
         <ResourceBaseClass Value="Frame"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="82" Y="9"/>
-        <UsageCount Value="171"/>
+        <UsageCount Value="170"/>
       </Unit47>
       <Unit48>
         <Filename Value="..\FPC_Unit\Auf\synhighlighterauf.pas"/>
         <UnitName Value="SynHighlighterAuf"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit48>
       <Unit49>
         <Filename Value="rtfp_pdfium.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="164"/>
         <CursorPos X="60" Y="191"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit49>
       <Unit50>
         <Filename Value="rtfp_pdfobj.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="217"/>
         <CursorPos X="73" Y="217"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit50>
       <Unit51>
         <Filename Value="rtfp_definition.pas"/>
@@ -492,69 +493,69 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="230"/>
         <CursorPos X="14" Y="242"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit51>
       <Unit52>
         <Filename Value="rtfp_field.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="76"/>
         <CursorPos X="15" Y="90"/>
-        <UsageCount Value="181"/>
+        <UsageCount Value="180"/>
       </Unit52>
       <Unit53>
         <Filename Value="rtfp_class.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
         <CursorPos X="15" Y="17"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit53>
       <Unit54>
         <Filename Value="rtfp_files.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="74"/>
         <CursorPos X="45" Y="77"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit54>
       <Unit55>
         <Filename Value="rtfp_constants.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="42" Y="15"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit55>
       <Unit56>
         <Filename Value="rtfp_format_component.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="503"/>
         <CursorPos X="48" Y="506"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit56>
       <Unit57>
         <Filename Value="rtfp_tags.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="46" Y="155"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit57>
       <Unit58>
         <Filename Value="rtfp_misc.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="20" Y="33"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit58>
       <Unit59>
         <Filename Value="rtfp_dialog.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="43" Y="40"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit59>
       <Unit60>
         <Filename Value="rtfp_type.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6"/>
         <CursorPos X="30" Y="28"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit60>
       <Unit61>
         <Filename Value="form_new_project.pas"/>
@@ -564,7 +565,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="91"/>
         <CursorPos X="54" Y="108"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit61>
       <Unit62>
         <Filename Value="form_cite_trans.pas"/>
@@ -574,7 +575,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="35"/>
         <CursorPos X="90" Y="39"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit62>
       <Unit63>
         <Filename Value="form_import.pas"/>
@@ -584,7 +585,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="264"/>
         <CursorPos X="96" Y="265"/>
-        <UsageCount Value="182"/>
+        <UsageCount Value="181"/>
       </Unit63>
       <Unit64>
         <Filename Value="form_classmanager.pas"/>
@@ -594,7 +595,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="81" Y="27"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit64>
       <Unit65>
         <Filename Value="form_appearance.pas"/>
@@ -603,7 +604,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="102" Y="3"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit65>
       <Unit66>
         <Filename Value="form_options.pas"/>
@@ -613,7 +614,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="41"/>
         <CursorPos X="42" Y="43"/>
-        <UsageCount Value="178"/>
+        <UsageCount Value="177"/>
       </Unit66>
       <Unit67>
         <Filename Value="form_report_tool.pas"/>
@@ -623,7 +624,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="20"/>
         <CursorPos X="74" Y="22"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit67>
       <Unit68>
         <Filename Value="form_repeated_checker.pas"/>
@@ -633,7 +634,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="291"/>
         <CursorPos X="46" Y="292"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit68>
       <Unit69>
         <Filename Value="form_project_profile.pas"/>
@@ -642,7 +643,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="55" Y="4"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit69>
       <Unit70>
         <Filename Value="form_field_display_option.pas"/>
@@ -652,7 +653,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="46"/>
         <CursorPos X="65" Y="49"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit70>
       <Unit71>
         <Filename Value="form_formatedit_option.pas"/>
@@ -662,7 +663,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="130"/>
         <CursorPos X="15" Y="121"/>
-        <UsageCount Value="178"/>
+        <UsageCount Value="177"/>
       </Unit71>
       <Unit72>
         <Filename Value="..\AufScript\aufscript_frame.pas"/>
@@ -682,7 +683,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="3540"/>
         <CursorPos Y="3558"/>
-        <UsageCount Value="180"/>
+        <UsageCount Value="179"/>
       </Unit73>
       <Unit74>
         <Filename Value="..\AufScript\auf_ram_var.pas"/>
@@ -690,13 +691,13 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit74>
       <Unit75>
         <Filename Value="..\FPC_Unit\Auf\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="161"/>
+        <UsageCount Value="160"/>
       </Unit75>
       <Unit76>
         <Filename Value="..\FPC_Unit\ACL\ListViewEx\acl_listview.pas"/>
@@ -704,14 +705,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="34"/>
         <CursorPos Y="66"/>
-        <UsageCount Value="60"/>
+        <UsageCount Value="59"/>
       </Unit76>
       <Unit77>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\systemh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1119"/>
         <CursorPos X="11" Y="1136"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit77>
       <Unit78>
         <Filename Value="D:\Lazarus\lcl\stdctrls.pp"/>
@@ -719,28 +720,28 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="483"/>
         <CursorPos X="3" Y="497"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit78>
       <Unit79>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="178"/>
         <CursorPos X="3" Y="197"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit79>
       <Unit80>
         <Filename Value="C:\lazarus\lcl\include\picture.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="560"/>
         <CursorPos X="11" Y="577"/>
-        <UsageCount Value="7"/>
+        <UsageCount Value="6"/>
       </Unit80>
       <Unit81>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="1636"/>
-        <CursorPos X="26" Y="1660"/>
-        <UsageCount Value="8"/>
+        <TopLine Value="197"/>
+        <CursorPos X="14" Y="217"/>
+        <UsageCount Value="10"/>
       </Unit81>
       <Unit82>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\bufdataset.pas"/>
@@ -748,459 +749,425 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="582"/>
         <CursorPos X="29" Y="612"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit82>
       <Unit83>
-        <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="485"/>
-        <CursorPos X="17" Y="497"/>
-        <UsageCount Value="1"/>
-      </Unit83>
-      <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\ascdef.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="102"/>
         <CursorPos X="10" Y="122"/>
-        <UsageCount Value="5"/>
-      </Unit84>
-      <Unit85>
+        <UsageCount Value="4"/>
+      </Unit83>
+      <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win64\system.pp"/>
         <UnitName Value="System"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="121"/>
         <CursorPos Y="16"/>
-        <UsageCount Value="5"/>
-      </Unit85>
-      <Unit86>
+        <UsageCount Value="4"/>
+      </Unit84>
+      <Unit85>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\system.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="73"/>
         <CursorPos X="34" Y="10"/>
-        <UsageCount Value="5"/>
-      </Unit86>
-      <Unit87>
+        <UsageCount Value="4"/>
+      </Unit85>
+      <Unit86>
         <Filename Value="data_access.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="449"/>
         <CursorPos X="3" Y="32"/>
-        <UsageCount Value="5"/>
-      </Unit87>
-      <Unit88>
+        <UsageCount Value="4"/>
+      </Unit86>
+      <Unit87>
         <Filename Value="formatedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="141"/>
         <CursorPos X="68" Y="263"/>
-        <UsageCount Value="5"/>
-      </Unit88>
-      <Unit89>
+        <UsageCount Value="4"/>
+      </Unit87>
+      <Unit88>
         <Filename Value="papers.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="54" Y="4"/>
-        <UsageCount Value="5"/>
-      </Unit89>
-      <Unit90>
+        <UsageCount Value="4"/>
+      </Unit88>
+      <Unit89>
         <Filename Value="events.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21" Y="10"/>
-        <UsageCount Value="5"/>
-      </Unit90>
-      <Unit91>
+        <UsageCount Value="4"/>
+      </Unit89>
+      <Unit90>
         <Filename Value="tags.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="32" Y="10"/>
-        <UsageCount Value="5"/>
-      </Unit91>
-      <Unit92>
+        <UsageCount Value="4"/>
+      </Unit90>
+      <Unit91>
         <Filename Value="paper.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="5" Y="3"/>
-        <UsageCount Value="5"/>
-      </Unit92>
-      <Unit93>
+        <UsageCount Value="4"/>
+      </Unit91>
+      <Unit92>
         <Filename Value="cite_tool.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="667"/>
         <CursorPos X="40" Y="679"/>
-        <UsageCount Value="7"/>
-      </Unit93>
-      <Unit94>
+        <UsageCount Value="6"/>
+      </Unit92>
+      <Unit93>
         <Filename Value="forms\form_classmanager.lfm"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
-      </Unit94>
-      <Unit95>
+      </Unit93>
+      <Unit94>
         <Filename Value="D:\Lazarus\components\synedit\synhighlighterunixshellscript.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="70"/>
         <CursorPos X="25" Y="73"/>
-        <UsageCount Value="5"/>
-      </Unit95>
-      <Unit96>
+        <UsageCount Value="4"/>
+      </Unit94>
+      <Unit95>
         <Filename Value="C:\lazarus\lcl\dbgrids.pas"/>
         <UnitName Value="DBGrids"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="535"/>
         <CursorPos X="25" Y="563"/>
-        <UsageCount Value="5"/>
-      </Unit96>
-      <Unit97>
-        <Filename Value="C:\lazarus\lcl\include\customedit.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="81"/>
-        <CursorPos Y="100"/>
-        <UsageCount Value="1"/>
-      </Unit97>
-      <Unit98>
-        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\fields.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="38"/>
-        <CursorPos Y="42"/>
-        <UsageCount Value="1"/>
-      </Unit98>
-      <Unit99>
+        <UsageCount Value="4"/>
+      </Unit95>
+      <Unit96>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\registry.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="79"/>
         <CursorPos X="25" Y="104"/>
-        <UsageCount Value="7"/>
-      </Unit99>
-      <Unit100>
+        <UsageCount Value="6"/>
+      </Unit96>
+      <Unit97>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\winreg.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="167"/>
         <CursorPos X="3" Y="172"/>
-        <UsageCount Value="7"/>
-      </Unit100>
-      <Unit101>
+        <UsageCount Value="6"/>
+      </Unit97>
+      <Unit98>
         <Filename Value="C:\lazarus\lcl\forms.pp"/>
         <UnitName Value="Forms"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="768"/>
         <CursorPos X="14" Y="784"/>
-        <UsageCount Value="3"/>
-      </Unit101>
-      <Unit102>
+        <UsageCount Value="2"/>
+      </Unit98>
+      <Unit99>
         <Filename Value="C:\lazarus\lcl\include\control.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2236"/>
         <CursorPos Y="2253"/>
-        <UsageCount Value="10"/>
-      </Unit102>
-      <Unit103>
+        <UsageCount Value="9"/>
+      </Unit99>
+      <Unit100>
         <Filename Value="C:\lazarus\lcl\include\wincontrol.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="5381"/>
-        <CursorPos Y="5398"/>
+        <TopLine Value="6808"/>
+        <CursorPos Y="6825"/>
         <UsageCount Value="10"/>
-      </Unit103>
-      <Unit104>
-        <Filename Value="C:\lazarus\lcl\include\fpimagebitmap.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="123"/>
-        <CursorPos Y="141"/>
-        <UsageCount Value="1"/>
-      </Unit104>
-      <Unit105>
+      </Unit100>
+      <Unit101>
         <Filename Value="C:\lazarus\lcl\extctrls.pp"/>
         <UnitName Value="ExtCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1035"/>
         <CursorPos X="17" Y="1053"/>
-        <UsageCount Value="2"/>
-      </Unit105>
-      <Unit106>
+        <UsageCount Value="1"/>
+      </Unit101>
+      <Unit102>
         <Filename Value="C:\lazarus\lcl\graphics.pp"/>
         <UnitName Value="Graphics"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="679"/>
         <CursorPos X="3" Y="698"/>
-        <UsageCount Value="5"/>
-      </Unit106>
-      <Unit107>
+        <UsageCount Value="4"/>
+      </Unit102>
+      <Unit103>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\regexpr\src\regexpr.pas"/>
         <UnitName Value="RegExpr"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="416"/>
         <CursorPos X="33" Y="298"/>
-        <UsageCount Value="7"/>
-      </Unit107>
-      <Unit108>
-        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysunih.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="19"/>
-        <CursorPos X="10" Y="48"/>
-        <UsageCount Value="1"/>
-      </Unit108>
-      <Unit109>
+        <UsageCount Value="6"/>
+      </Unit103>
+      <Unit104>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-image\src\fpcanvas.pp"/>
         <UnitName Value="FPCanvas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="36" Y="158"/>
-        <UsageCount Value="7"/>
-      </Unit109>
-      <Unit110>
+        <UsageCount Value="6"/>
+      </Unit104>
+      <Unit105>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\memds\memds.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="127"/>
         <CursorPos X="74" Y="154"/>
-        <UsageCount Value="9"/>
-      </Unit110>
-      <Unit111>
+        <UsageCount Value="8"/>
+      </Unit105>
+      <Unit106>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysuni.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="267"/>
         <CursorPos X="5" Y="277"/>
-        <UsageCount Value="10"/>
-      </Unit111>
-      <Unit112>
+        <UsageCount Value="9"/>
+      </Unit106>
+      <Unit107>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\lists.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="773"/>
         <CursorPos Y="775"/>
-        <UsageCount Value="5"/>
-      </Unit112>
-      <Unit113>
+        <UsageCount Value="4"/>
+      </Unit107>
+      <Unit108>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\sqldb\sqldb.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="576"/>
         <CursorPos X="14" Y="593"/>
-        <UsageCount Value="10"/>
-      </Unit113>
-      <Unit114>
-        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\database.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="21"/>
-        <CursorPos Y="21"/>
-        <UsageCount Value="1"/>
-      </Unit114>
-      <Unit115>
+        <UsageCount Value="9"/>
+      </Unit108>
+      <Unit109>
         <Filename Value="C:\lazarus\lcl\stdctrls.pp"/>
         <UnitName Value="StdCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="704"/>
         <CursorPos X="30" Y="727"/>
-        <UsageCount Value="10"/>
-      </Unit115>
-      <Unit116>
+        <UsageCount Value="9"/>
+      </Unit109>
+      <Unit110>
         <Filename Value="C:\lazarus\lcl\controls.pp"/>
         <UnitName Value="Controls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="206"/>
         <CursorPos X="3" Y="224"/>
-        <UsageCount Value="3"/>
-      </Unit116>
-      <Unit117>
+        <UsageCount Value="2"/>
+      </Unit110>
+      <Unit111>
         <Filename Value="C:\lazarus\lcl\lclclasses.pp"/>
         <UnitName Value="LCLClasses"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="24"/>
         <CursorPos X="3" Y="42"/>
-        <UsageCount Value="10"/>
-      </Unit117>
-      <Unit118>
+        <UsageCount Value="9"/>
+      </Unit111>
+      <Unit112>
         <Filename Value="..\ACL_ListView\acl_listview.pas"/>
         <UnitName Value="ACL_ListView"/>
         <EditorIndex Value="1"/>
         <TopLine Value="20"/>
         <CursorPos X="17" Y="30"/>
-        <UsageCount Value="45"/>
+        <UsageCount Value="55"/>
         <Loaded Value="True"/>
-      </Unit118>
-      <Unit119>
+      </Unit112>
+      <Unit113>
         <Filename Value="C:\lazarus\lcl\lclmessageglue.pas"/>
         <UnitName Value="LCLMessageGlue"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="95"/>
         <CursorPos Y="112"/>
-        <UsageCount Value="10"/>
-      </Unit119>
-      <Unit120>
+        <UsageCount Value="9"/>
+      </Unit113>
+      <Unit114>
         <Filename Value="C:\lazarus\lcl\interfaces\win32\win32callback.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2652"/>
         <CursorPos Y="2671"/>
-        <UsageCount Value="10"/>
-      </Unit120>
-      <Unit121>
+        <UsageCount Value="9"/>
+      </Unit114>
+      <Unit115>
         <Filename Value="C:\lazarus\lcl\include\customlistview.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1350"/>
         <CursorPos Y="1385"/>
-        <UsageCount Value="4"/>
-      </Unit121>
-      <Unit122>
+        <UsageCount Value="3"/>
+      </Unit115>
+      <Unit116>
         <Filename Value="C:\lazarus\lcl\include\listitems.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos Y="27"/>
-        <UsageCount Value="4"/>
-      </Unit122>
-      <Unit123>
+        <UsageCount Value="3"/>
+      </Unit116>
+      <Unit117>
         <Filename Value="C:\lazarus\lcl\comctrls.pp"/>
         <UnitName Value="ComCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="974"/>
         <CursorPos X="3" Y="992"/>
-        <UsageCount Value="3"/>
-      </Unit123>
-      <Unit124>
+        <UsageCount Value="2"/>
+      </Unit117>
+      <Unit118>
         <Filename Value="rtfp_core\rtfp_db_sorter.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="13"/>
-        <UsageCount Value="15"/>
-      </Unit124>
-      <Unit125>
+        <UsageCount Value="14"/>
+      </Unit118>
+      <Unit119>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysutilh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="302"/>
         <CursorPos X="13" Y="320"/>
-        <UsageCount Value="6"/>
-      </Unit125>
-      <Unit126>
+        <UsageCount Value="5"/>
+      </Unit119>
+      <Unit120>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysutils.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="154"/>
         <CursorPos X="9" Y="158"/>
-        <UsageCount Value="5"/>
-      </Unit126>
-      <Unit127>
+        <UsageCount Value="4"/>
+      </Unit120>
+      <Unit121>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\inc\objpash.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="176"/>
         <CursorPos X="23" Y="194"/>
-        <UsageCount Value="5"/>
-      </Unit127>
-      <Unit128>
+        <UsageCount Value="4"/>
+      </Unit121>
+      <Unit122>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\dataset.inc"/>
-        <EditorIndex Value="20"/>
+        <EditorIndex Value="21"/>
         <TopLine Value="2001"/>
         <CursorPos X="3" Y="2017"/>
-        <UsageCount Value="20"/>
+        <UsageCount Value="30"/>
         <Loaded Value="True"/>
-      </Unit128>
+      </Unit122>
+      <Unit123>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\fields.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="241"/>
+        <CursorPos X="71" Y="244"/>
+        <UsageCount Value="10"/>
+      </Unit123>
     </Units>
-    <JumpHistory Count="30" HistoryIndex="29">
+    <JumpHistory Count="30" HistoryIndex="27">
       <Position1>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="1705" Column="3" TopLine="1696"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="385" TopLine="366"/>
       </Position1>
       <Position2>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="1707" Column="3" TopLine="1698"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="387" TopLine="366"/>
       </Position2>
       <Position3>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2256" Column="3" TopLine="2254"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="384" TopLine="366"/>
       </Position3>
       <Position4>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2245" TopLine="2234"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="391" TopLine="366"/>
       </Position4>
       <Position5>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2261" Column="24" TopLine="2243"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="381" TopLine="366"/>
       </Position5>
       <Position6>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2286" Column="3" TopLine="2284"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="382" TopLine="366"/>
       </Position6>
       <Position7>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2301" TopLine="2299"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="383" TopLine="366"/>
       </Position7>
       <Position8>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2290" Column="64" TopLine="2276"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="384" TopLine="366"/>
       </Position8>
       <Position9>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2295" Column="3" TopLine="2293"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="385" TopLine="366"/>
       </Position9>
       <Position10>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2459" TopLine="2457"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="386" TopLine="366"/>
       </Position10>
       <Position11>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2297" Column="3" TopLine="2281"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="382" TopLine="363"/>
       </Position11>
       <Position12>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2478" TopLine="2469"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="381" TopLine="363"/>
       </Position12>
       <Position13>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2307" Column="29" TopLine="2302"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="382" TopLine="363"/>
       </Position13>
       <Position14>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="25" Column="19" TopLine="16"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="383" TopLine="363"/>
       </Position14>
       <Position15>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="99" Column="27" TopLine="70"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="384" TopLine="363"/>
       </Position15>
       <Position16>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2263" Column="64" TopLine="2245"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="385" TopLine="363"/>
       </Position16>
       <Position17>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2297" Column="3" TopLine="2295"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="386" TopLine="363"/>
       </Position17>
       <Position18>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2264" Column="29" TopLine="2246"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="1955" Column="3" TopLine="674"/>
       </Position18>
       <Position19>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="372" Column="15" TopLine="355"/>
+        <Filename Value="rtfp_core\control_interface.inc"/>
+        <Caret Line="386" Column="15" TopLine="363"/>
       </Position19>
       <Position20>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="572" Column="12" TopLine="556"/>
+        <Filename Value="forms\form_report_tool.pas"/>
+        <Caret Line="419" Column="28" TopLine="399"/>
       </Position20>
       <Position21>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="579" Column="11" TopLine="552"/>
+        <Filename Value="forms\form_report_tool.pas"/>
+        <Caret Line="420" Column="11" TopLine="405"/>
       </Position21>
       <Position22>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="589" Column="11" TopLine="564"/>
+        <Filename Value="rtfp_core\access_field.inc"/>
+        <Caret Line="11" Column="34"/>
       </Position22>
       <Position23>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="556" Column="47" TopLine="548"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="207" TopLine="195"/>
       </Position23>
       <Position24>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="577" Column="57" TopLine="560"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="202" TopLine="195"/>
       </Position24>
       <Position25>
-        <Filename Value="rtfp_core\rtfp_files.pas"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="203" TopLine="195"/>
       </Position25>
       <Position26>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2264" Column="21" TopLine="2249"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="205" TopLine="195"/>
       </Position26>
       <Position27>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="372" Column="15" TopLine="354"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="206" Column="23" TopLine="191"/>
       </Position27>
       <Position28>
         <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="155" Column="80" TopLine="161"/>
+        <Caret Line="207" Column="57" TopLine="191"/>
       </Position28>
       <Position29>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="210" Column="51" TopLine="192"/>
+        <Filename Value="RTFP_Desktop.lpr"/>
+        <Caret Line="20" TopLine="3"/>
       </Position29>
       <Position30>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2270" Column="43" TopLine="2249"/>
+        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
+        <Caret Line="170" Column="20" TopLine="143"/>
       </Position30>
     </JumpHistory>
   </ProjectSession>

--- a/RTFP_Desktop.lps
+++ b/RTFP_Desktop.lps
@@ -4,7 +4,7 @@
     <PathDelim Value="\"/>
     <Version Value="10"/>
     <BuildModes Active="Default"/>
-    <Units Count="122">
+    <Units Count="125">
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -20,8 +20,9 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="RTFP_main"/>
-        <TopLine Value="133"/>
-        <CursorPos X="40" Y="20"/>
+        <IsVisibleTab Value="True"/>
+        <TopLine Value="2268"/>
+        <CursorPos X="5" Y="2288"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -32,7 +33,7 @@
         <ComponentName Value="Form_FileSource"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="33"/>
+        <EditorIndex Value="34"/>
         <TopLine Value="73"/>
         <CursorPos X="16" Y="87"/>
         <UsageCount Value="202"/>
@@ -42,7 +43,7 @@
       <Unit3>
         <Filename Value="sync\sync_timer.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="34"/>
+        <EditorIndex Value="35"/>
         <TopLine Value="7"/>
         <CursorPos X="16" Y="25"/>
         <UsageCount Value="200"/>
@@ -64,7 +65,7 @@
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="23"/>
+        <EditorIndex Value="24"/>
         <TopLine Value="136"/>
         <CursorPos X="13" Y="150"/>
         <UsageCount Value="201"/>
@@ -77,7 +78,7 @@
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="32"/>
+        <EditorIndex Value="33"/>
         <TopLine Value="177"/>
         <CursorPos X="22" Y="192"/>
         <UsageCount Value="201"/>
@@ -90,7 +91,7 @@
         <ComponentName Value="FormFieldDisplayOption"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="10"/>
+        <EditorIndex Value="11"/>
         <TopLine Value="40"/>
         <CursorPos X="10" Y="68"/>
         <UsageCount Value="201"/>
@@ -122,7 +123,7 @@
         <ComponentName Value="Form_NewProject"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="13"/>
+        <EditorIndex Value="14"/>
         <TopLine Value="20"/>
         <CursorPos X="79" Y="31"/>
         <UsageCount Value="201"/>
@@ -135,7 +136,7 @@
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="27"/>
+        <EditorIndex Value="28"/>
         <TopLine Value="179"/>
         <CursorPos X="24" Y="191"/>
         <UsageCount Value="201"/>
@@ -156,7 +157,7 @@
         <Filename Value="forms\form_repeated_checker.pas"/>
         <IsPartOfProject Value="True"/>
         <HasResources Value="True"/>
-        <EditorIndex Value="2"/>
+        <EditorIndex Value="3"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit13>
@@ -166,7 +167,7 @@
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="31"/>
+        <EditorIndex Value="32"/>
         <TopLine Value="432"/>
         <CursorPos X="33" Y="452"/>
         <UsageCount Value="201"/>
@@ -176,17 +177,17 @@
       <Unit15>
         <Filename Value="rtfp_core\rtfp_class.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="26"/>
-        <CursorPos X="22" Y="74"/>
+        <EditorIndex Value="27"/>
+        <TopLine Value="101"/>
+        <CursorPos X="7" Y="201"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit15>
       <Unit16>
         <Filename Value="rtfp_core\rtfp_constants.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="29"/>
-        <TopLine Value="16"/>
-        <CursorPos X="3" Y="52"/>
+        <EditorIndex Value="30"/>
+        <CursorPos X="43" Y="42"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit16>
@@ -194,7 +195,7 @@
         <Filename Value="rtfp_core\rtfp_definition.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="RTFP_definition"/>
-        <EditorIndex Value="17"/>
+        <EditorIndex Value="18"/>
         <TopLine Value="279"/>
         <CursorPos X="3" Y="93"/>
         <UsageCount Value="201"/>
@@ -203,16 +204,16 @@
       <Unit18>
         <Filename Value="rtfp_core\rtfp_dialog.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="35"/>
-        <TopLine Value="112"/>
-        <CursorPos X="5" Y="130"/>
+        <EditorIndex Value="36"/>
+        <TopLine Value="307"/>
+        <CursorPos Y="127"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit18>
       <Unit19>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="14"/>
+        <EditorIndex Value="15"/>
         <TopLine Value="46"/>
         <CursorPos X="57" Y="63"/>
         <UsageCount Value="201"/>
@@ -221,24 +222,22 @@
       <Unit20>
         <Filename Value="rtfp_core\rtfp_files.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="22"/>
-        <TopLine Value="79"/>
+        <EditorIndex Value="23"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit20>
       <Unit21>
         <Filename Value="rtfp_core\rtfp_format_component.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="30"/>
-        <TopLine Value="34"/>
-        <CursorPos X="3" Y="46"/>
+        <EditorIndex Value="31"/>
+        <CursorPos X="33" Y="29"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit21>
       <Unit22>
         <Filename Value="rtfp_core\rtfp_misc.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="24"/>
+        <EditorIndex Value="25"/>
         <TopLine Value="67"/>
         <CursorPos Y="28"/>
         <UsageCount Value="201"/>
@@ -256,7 +255,7 @@
       <Unit24>
         <Filename Value="rtfp_core\rtfp_type.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="25"/>
+        <EditorIndex Value="26"/>
         <CursorPos X="46" Y="13"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -264,7 +263,7 @@
       <Unit25>
         <Filename Value="rtfp_pdf\rtfp_pdfium.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="16"/>
+        <EditorIndex Value="17"/>
         <TopLine Value="108"/>
         <CursorPos X="29" Y="135"/>
         <UsageCount Value="200"/>
@@ -273,7 +272,7 @@
       <Unit26>
         <Filename Value="rtfp_pdf\rtfp_pdfobj.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="15"/>
+        <EditorIndex Value="16"/>
         <TopLine Value="165"/>
         <CursorPos X="32" Y="173"/>
         <UsageCount Value="200"/>
@@ -282,8 +281,7 @@
       <Unit27>
         <Filename Value="rtfp_core\formatedit_list.inc"/>
         <IsPartOfProject Value="True"/>
-        <IsVisibleTab Value="True"/>
-        <EditorIndex Value="4"/>
+        <EditorIndex Value="5"/>
         <TopLine Value="93"/>
         <CursorPos X="22" Y="105"/>
         <UsageCount Value="200"/>
@@ -292,7 +290,7 @@
       <Unit28>
         <Filename Value="rtfp_core\packed_format.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="1"/>
+        <EditorIndex Value="2"/>
         <TopLine Value="4"/>
         <CursorPos X="34" Y="21"/>
         <UsageCount Value="200"/>
@@ -304,55 +302,55 @@
         <ComponentName Value="Form_FieldChange"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="11"/>
+        <EditorIndex Value="12"/>
         <TopLine Value="94"/>
         <CursorPos X="3" Y="99"/>
-        <UsageCount Value="160"/>
+        <UsageCount Value="179"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit29>
       <Unit30>
         <Filename Value="rtfp_core\rtfp_field_convert.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="12"/>
+        <EditorIndex Value="13"/>
         <TopLine Value="79"/>
         <CursorPos X="40" Y="55"/>
-        <UsageCount Value="148"/>
+        <UsageCount Value="167"/>
         <Loaded Value="True"/>
       </Unit30>
       <Unit31>
         <Filename Value="rtfp_core\formatedit_component.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="3"/>
-        <TopLine Value="91"/>
-        <CursorPos X="114" Y="101"/>
-        <UsageCount Value="159"/>
+        <EditorIndex Value="4"/>
+        <TopLine Value="79"/>
+        <CursorPos X="53" Y="100"/>
+        <UsageCount Value="178"/>
         <Loaded Value="True"/>
       </Unit31>
       <Unit32>
         <Filename Value="rtfp_core\access_field.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="20"/>
+        <EditorIndex Value="21"/>
         <CursorPos X="34" Y="11"/>
-        <UsageCount Value="158"/>
+        <UsageCount Value="177"/>
         <Loaded Value="True"/>
       </Unit32>
       <Unit33>
         <Filename Value="rtfp_core\control_interface.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="21"/>
+        <EditorIndex Value="22"/>
         <TopLine Value="322"/>
         <CursorPos X="62" Y="341"/>
-        <UsageCount Value="158"/>
+        <UsageCount Value="177"/>
         <Loaded Value="True"/>
       </Unit33>
       <Unit34>
         <Filename Value="rtfp_core\access_data.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="5"/>
-        <TopLine Value="216"/>
-        <CursorPos X="91" Y="224"/>
-        <UsageCount Value="158"/>
+        <EditorIndex Value="6"/>
+        <TopLine Value="207"/>
+        <CursorPos X="63" Y="235"/>
+        <UsageCount Value="177"/>
         <Loaded Value="True"/>
       </Unit34>
       <Unit35>
@@ -361,40 +359,40 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="393"/>
         <CursorPos X="39" Y="415"/>
-        <UsageCount Value="152"/>
+        <UsageCount Value="171"/>
       </Unit35>
       <Unit36>
         <Filename Value="rtfp_core\aufunc.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="6"/>
+        <EditorIndex Value="7"/>
         <TopLine Value="423"/>
         <CursorPos X="28" Y="439"/>
-        <UsageCount Value="144"/>
+        <UsageCount Value="163"/>
         <Loaded Value="True"/>
       </Unit36>
       <Unit37>
         <Filename Value="rtfp_core\access_base.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="9"/>
+        <EditorIndex Value="10"/>
         <TopLine Value="256"/>
         <CursorPos X="27" Y="300"/>
-        <UsageCount Value="133"/>
+        <UsageCount Value="152"/>
         <Loaded Value="True"/>
       </Unit37>
       <Unit38>
         <Filename Value="rtfp_core\events.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="19"/>
+        <EditorIndex Value="20"/>
         <CursorPos X="23" Y="20"/>
-        <UsageCount Value="129"/>
+        <UsageCount Value="148"/>
         <Loaded Value="True"/>
       </Unit38>
       <Unit39>
         <Filename Value="rtfp_core\access_attrs.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="28"/>
+        <EditorIndex Value="29"/>
         <CursorPos X="27" Y="16"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
         <Loaded Value="True"/>
       </Unit39>
       <Unit40>
@@ -404,7 +402,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
       </Unit40>
       <Unit41>
         <Filename Value="rtfp_core\image.inc"/>
@@ -413,7 +411,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
       </Unit41>
       <Unit42>
         <Filename Value="rtfp_core\notes.inc"/>
@@ -422,15 +420,15 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
       </Unit42>
       <Unit43>
         <Filename Value="rtfp_core\paper.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="18"/>
+        <EditorIndex Value="19"/>
         <TopLine Value="458"/>
         <CursorPos X="16" Y="464"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
         <Loaded Value="True"/>
       </Unit43>
       <Unit44>
@@ -440,7 +438,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
       </Unit44>
       <Unit45>
         <Filename Value="rtfp_core\update.inc"/>
@@ -449,7 +447,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="117"/>
+        <UsageCount Value="136"/>
       </Unit45>
       <Unit46>
         <Filename Value="..\FPC_Unit\Auf\aufscript_frame.pas"/>
@@ -458,27 +456,27 @@
         <ResourceBaseClass Value="Frame"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="82" Y="9"/>
-        <UsageCount Value="179"/>
+        <UsageCount Value="178"/>
       </Unit46>
       <Unit47>
         <Filename Value="..\FPC_Unit\Auf\synhighlighterauf.pas"/>
         <UnitName Value="SynHighlighterAuf"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="14"/>
+        <UsageCount Value="13"/>
       </Unit47>
       <Unit48>
         <Filename Value="rtfp_pdfium.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="164"/>
         <CursorPos X="60" Y="191"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit48>
       <Unit49>
         <Filename Value="rtfp_pdfobj.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="217"/>
         <CursorPos X="73" Y="217"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit49>
       <Unit50>
         <Filename Value="rtfp_definition.pas"/>
@@ -486,69 +484,69 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="230"/>
         <CursorPos X="14" Y="242"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit50>
       <Unit51>
         <Filename Value="rtfp_field.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="76"/>
         <CursorPos X="15" Y="90"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="188"/>
       </Unit51>
       <Unit52>
         <Filename Value="rtfp_class.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
         <CursorPos X="15" Y="17"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit52>
       <Unit53>
         <Filename Value="rtfp_files.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="74"/>
         <CursorPos X="45" Y="77"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit53>
       <Unit54>
         <Filename Value="rtfp_constants.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="42" Y="15"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit54>
       <Unit55>
         <Filename Value="rtfp_format_component.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="503"/>
         <CursorPos X="48" Y="506"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit55>
       <Unit56>
         <Filename Value="rtfp_tags.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="46" Y="155"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit56>
       <Unit57>
         <Filename Value="rtfp_misc.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="20" Y="33"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit57>
       <Unit58>
         <Filename Value="rtfp_dialog.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="43" Y="40"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit58>
       <Unit59>
         <Filename Value="rtfp_type.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6"/>
         <CursorPos X="30" Y="28"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit59>
       <Unit60>
         <Filename Value="form_new_project.pas"/>
@@ -558,7 +556,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="91"/>
         <CursorPos X="54" Y="108"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit60>
       <Unit61>
         <Filename Value="form_cite_trans.pas"/>
@@ -568,7 +566,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="35"/>
         <CursorPos X="90" Y="39"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit61>
       <Unit62>
         <Filename Value="form_import.pas"/>
@@ -578,7 +576,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="264"/>
         <CursorPos X="96" Y="265"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="189"/>
       </Unit62>
       <Unit63>
         <Filename Value="form_classmanager.pas"/>
@@ -588,7 +586,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="81" Y="27"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit63>
       <Unit64>
         <Filename Value="form_appearance.pas"/>
@@ -597,7 +595,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="102" Y="3"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit64>
       <Unit65>
         <Filename Value="form_options.pas"/>
@@ -607,7 +605,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="41"/>
         <CursorPos X="42" Y="43"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit65>
       <Unit66>
         <Filename Value="form_report_tool.pas"/>
@@ -617,7 +615,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="20"/>
         <CursorPos X="74" Y="22"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit66>
       <Unit67>
         <Filename Value="form_repeated_checker.pas"/>
@@ -627,7 +625,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="291"/>
         <CursorPos X="46" Y="292"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit67>
       <Unit68>
         <Filename Value="form_project_profile.pas"/>
@@ -636,7 +634,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="55" Y="4"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit68>
       <Unit69>
         <Filename Value="form_field_display_option.pas"/>
@@ -646,7 +644,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="46"/>
         <CursorPos X="65" Y="49"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit69>
       <Unit70>
         <Filename Value="form_formatedit_option.pas"/>
@@ -656,23 +654,24 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="130"/>
         <CursorPos X="15" Y="121"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit70>
       <Unit71>
         <Filename Value="..\AufScript\aufscript_frame.pas"/>
         <ComponentName Value="Frame_AufScript"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Frame"/>
-        <EditorIndex Value="8"/>
-        <TopLine Value="87"/>
-        <CursorPos Y="107"/>
+        <EditorIndex Value="9"/>
+        <TopLine Value="53"/>
+        <CursorPos X="22" Y="67"/>
         <UsageCount Value="185"/>
         <Loaded Value="True"/>
+        <LoadedDesigner Value="True"/>
       </Unit71>
       <Unit72>
         <Filename Value="..\AufScript\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
-        <EditorIndex Value="7"/>
+        <EditorIndex Value="8"/>
         <TopLine Value="4585"/>
         <CursorPos X="3" Y="4616"/>
         <UsageCount Value="185"/>
@@ -684,13 +683,13 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="183"/>
+        <UsageCount Value="182"/>
       </Unit73>
       <Unit74>
         <Filename Value="..\FPC_Unit\Auf\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="169"/>
+        <UsageCount Value="168"/>
       </Unit74>
       <Unit75>
         <Filename Value="..\FPC_Unit\ACL\ListViewEx\acl_listview.pas"/>
@@ -698,14 +697,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="34"/>
         <CursorPos Y="66"/>
-        <UsageCount Value="68"/>
+        <UsageCount Value="67"/>
       </Unit75>
       <Unit76>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\systemh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1119"/>
         <CursorPos X="11" Y="1136"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit76>
       <Unit77>
         <Filename Value="D:\Lazarus\lcl\stdctrls.pp"/>
@@ -713,28 +712,28 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="483"/>
         <CursorPos X="3" Y="497"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit77>
       <Unit78>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="479"/>
         <CursorPos X="17" Y="497"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit78>
       <Unit79>
         <Filename Value="C:\lazarus\lcl\include\picture.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="560"/>
         <CursorPos X="11" Y="577"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit79>
       <Unit80>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1924"/>
         <CursorPos X="3" Y="1942"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit80>
       <Unit81>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\bufdataset.pas"/>
@@ -742,21 +741,21 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="582"/>
         <CursorPos X="29" Y="612"/>
-        <UsageCount Value="7"/>
+        <UsageCount Value="6"/>
       </Unit81>
       <Unit82>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="485"/>
         <CursorPos X="17" Y="497"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit82>
       <Unit83>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\ascdef.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="102"/>
         <CursorPos X="10" Y="122"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit83>
       <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win64\system.pp"/>
@@ -764,65 +763,65 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="121"/>
         <CursorPos Y="16"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit84>
       <Unit85>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\system.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="73"/>
         <CursorPos X="34" Y="10"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit85>
       <Unit86>
         <Filename Value="data_access.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="449"/>
         <CursorPos X="3" Y="32"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit86>
       <Unit87>
         <Filename Value="formatedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="141"/>
         <CursorPos X="68" Y="263"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit87>
       <Unit88>
         <Filename Value="papers.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="54" Y="4"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit88>
       <Unit89>
         <Filename Value="events.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21" Y="10"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit89>
       <Unit90>
         <Filename Value="tags.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="32" Y="10"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit90>
       <Unit91>
         <Filename Value="paper.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="5" Y="3"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit91>
       <Unit92>
         <Filename Value="cite_tool.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="667"/>
         <CursorPos X="40" Y="679"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit92>
       <Unit93>
         <Filename Value="forms\form_classmanager.lfm"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
       </Unit93>
       <Unit94>
@@ -830,7 +829,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="70"/>
         <CursorPos X="25" Y="73"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit94>
       <Unit95>
         <Filename Value="C:\lazarus\lcl\dbgrids.pas"/>
@@ -838,78 +837,78 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="535"/>
         <CursorPos X="25" Y="563"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit95>
       <Unit96>
         <Filename Value="C:\lazarus\lcl\include\customedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="81"/>
         <CursorPos Y="100"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit96>
       <Unit97>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\fields.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="38"/>
         <CursorPos Y="42"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit97>
       <Unit98>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\registry.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="79"/>
         <CursorPos X="25" Y="104"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit98>
       <Unit99>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\winreg.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="167"/>
         <CursorPos X="3" Y="172"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit99>
       <Unit100>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\win\wininc\func.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="931"/>
         <CursorPos X="10" Y="949"/>
-        <UsageCount Value="2"/>
+        <UsageCount Value="1"/>
       </Unit100>
       <Unit101>
         <Filename Value="C:\lazarus\lcl\include\customform.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2935"/>
         <CursorPos Y="2962"/>
-        <UsageCount Value="2"/>
+        <UsageCount Value="1"/>
       </Unit101>
       <Unit102>
         <Filename Value="C:\lazarus\lcl\forms.pp"/>
         <UnitName Value="Forms"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="602"/>
-        <CursorPos X="3" Y="739"/>
-        <UsageCount Value="8"/>
+        <TopLine Value="768"/>
+        <CursorPos X="14" Y="784"/>
+        <UsageCount Value="10"/>
       </Unit102>
       <Unit103>
         <Filename Value="C:\lazarus\lcl\include\control.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2236"/>
         <CursorPos Y="2253"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit103>
       <Unit104>
         <Filename Value="C:\lazarus\lcl\include\wincontrol.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="5381"/>
         <CursorPos Y="5398"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit104>
       <Unit105>
         <Filename Value="C:\lazarus\lcl\include\fpimagebitmap.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="123"/>
         <CursorPos Y="141"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit105>
       <Unit106>
         <Filename Value="C:\lazarus\lcl\extctrls.pp"/>
@@ -917,7 +916,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="1035"/>
         <CursorPos X="17" Y="1053"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit106>
       <Unit107>
         <Filename Value="C:\lazarus\lcl\graphics.pp"/>
@@ -925,7 +924,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="679"/>
         <CursorPos X="3" Y="698"/>
-        <UsageCount Value="13"/>
+        <UsageCount Value="12"/>
       </Unit107>
       <Unit108>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\regexpr\src\regexpr.pas"/>
@@ -933,14 +932,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="416"/>
         <CursorPos X="33" Y="298"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit108>
       <Unit109>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysunih.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="19"/>
         <CursorPos X="10" Y="48"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit109>
       <Unit110>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-image\src\fpcanvas.pp"/>
@@ -948,42 +947,42 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="36" Y="158"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit110>
       <Unit111>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\memds\memds.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="127"/>
         <CursorPos X="74" Y="154"/>
-        <UsageCount Value="7"/>
+        <UsageCount Value="6"/>
       </Unit111>
       <Unit112>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysuni.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="267"/>
         <CursorPos X="5" Y="277"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit112>
       <Unit113>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\lists.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="297"/>
         <CursorPos Y="306"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit113>
       <Unit114>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\sqldb\sqldb.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="576"/>
         <CursorPos X="14" Y="593"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit114>
       <Unit115>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\database.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="21"/>
         <CursorPos Y="21"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit115>
       <Unit116>
         <Filename Value="C:\lazarus\lcl\stdctrls.pp"/>
@@ -991,15 +990,15 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="704"/>
         <CursorPos X="30" Y="727"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit116>
       <Unit117>
         <Filename Value="C:\lazarus\lcl\controls.pp"/>
         <UnitName Value="Controls"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="1914"/>
-        <CursorPos X="36" Y="1936"/>
-        <UsageCount Value="8"/>
+        <TopLine Value="206"/>
+        <CursorPos X="3" Y="224"/>
+        <UsageCount Value="10"/>
       </Unit117>
       <Unit118>
         <Filename Value="C:\lazarus\lcl\lclclasses.pp"/>
@@ -1007,14 +1006,16 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="24"/>
         <CursorPos X="3" Y="42"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit118>
       <Unit119>
         <Filename Value="..\ACL_ListView\acl_listview.pas"/>
         <UnitName Value="ACL_ListView"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="13"/>
-        <UsageCount Value="8"/>
+        <EditorIndex Value="1"/>
+        <TopLine Value="20"/>
+        <CursorPos X="17" Y="30"/>
+        <UsageCount Value="12"/>
+        <Loaded Value="True"/>
       </Unit119>
       <Unit120>
         <Filename Value="C:\lazarus\lcl\lclmessageglue.pas"/>
@@ -1022,136 +1023,157 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="95"/>
         <CursorPos Y="112"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit120>
       <Unit121>
         <Filename Value="C:\lazarus\lcl\interfaces\win32\win32callback.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2652"/>
         <CursorPos Y="2671"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit121>
+      <Unit122>
+        <Filename Value="C:\lazarus\lcl\include\customlistview.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="1350"/>
+        <CursorPos Y="1385"/>
+        <UsageCount Value="11"/>
+      </Unit122>
+      <Unit123>
+        <Filename Value="C:\lazarus\lcl\include\listitems.inc"/>
+        <EditorIndex Value="-1"/>
+        <CursorPos Y="27"/>
+        <UsageCount Value="11"/>
+      </Unit123>
+      <Unit124>
+        <Filename Value="C:\lazarus\lcl\comctrls.pp"/>
+        <UnitName Value="ComCtrls"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="974"/>
+        <CursorPos X="3" Y="992"/>
+        <UsageCount Value="10"/>
+      </Unit124>
     </Units>
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
-        <Filename Value="rtfp_core\aufunc.inc"/>
-        <Caret Line="496" TopLine="467"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="346" Column="31" TopLine="328"/>
       </Position1>
       <Position2>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="209" TopLine="192"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2375" Column="62" TopLine="2357"/>
       </Position2>
       <Position3>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="171" TopLine="159"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2284" Column="21" TopLine="2268"/>
       </Position3>
       <Position4>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="564" Column="43" TopLine="541"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2292" Column="16" TopLine="2277"/>
       </Position4>
       <Position5>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="717" Column="15" TopLine="694"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2287" Column="4" TopLine="2277"/>
       </Position5>
       <Position6>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="152" Column="15" TopLine="135"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2285" Column="39" TopLine="2255"/>
       </Position6>
       <Position7>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="472" Column="17" TopLine="446"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2372" Column="15" TopLine="2301"/>
       </Position7>
       <Position8>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="144" Column="14" TopLine="126"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2364" Column="43" TopLine="2349"/>
       </Position8>
       <Position9>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="171" TopLine="153"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2356" Column="77" TopLine="2353"/>
       </Position9>
       <Position10>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="346" Column="15" TopLine="325"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="196" Column="26" TopLine="179"/>
       </Position10>
       <Position11>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="472" Column="16" TopLine="442"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="772" Column="37" TopLine="743"/>
       </Position11>
       <Position12>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="144" Column="14" TopLine="126"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="773" Column="37" TopLine="744"/>
       </Position12>
       <Position13>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="407" Column="3" TopLine="396"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="374" Column="18" TopLine="359"/>
       </Position13>
       <Position14>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="211" Column="20" TopLine="192"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="816" Column="19" TopLine="789"/>
       </Position14>
       <Position15>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="45" Column="60" TopLine="33"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2382" Column="55" TopLine="2370"/>
       </Position15>
       <Position16>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="276" Column="83" TopLine="250"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="818" Column="32" TopLine="795"/>
       </Position16>
       <Position17>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="1936" Column="22" TopLine="1909"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="1677" TopLine="1659"/>
       </Position17>
       <Position18>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="1922" Column="35" TopLine="1909"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="1694" Column="33" TopLine="1685"/>
       </Position18>
       <Position19>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="1108" Column="27" TopLine="1086"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="71" Column="5" TopLine="54"/>
       </Position19>
       <Position20>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="221" Column="28" TopLine="209"/>
+        <Filename Value="..\AufScript\aufscript_frame.pas"/>
+        <Caret Line="63" Column="19" TopLine="46"/>
       </Position20>
       <Position21>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="24" TopLine="34"/>
+        <Filename Value="..\AufScript\aufscript_frame.pas"/>
+        <Caret Line="65" Column="87" TopLine="46"/>
       </Position21>
       <Position22>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="71" Column="59" TopLine="65"/>
+        <Filename Value="..\AufScript\aufscript_frame.pas"/>
+        <Caret Line="333" Column="49" TopLine="304"/>
       </Position22>
       <Position23>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="89" Column="7" TopLine="65"/>
+        <Filename Value="..\AufScript\aufscript_frame.pas"/>
+        <Caret Line="427" Column="49" TopLine="398"/>
       </Position23>
       <Position24>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="91" Column="19" TopLine="37"/>
+        <Filename Value="..\AufScript\aufscript_frame.pas"/>
+        <Caret Line="565" Column="19" TopLine="536"/>
       </Position24>
       <Position25>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="111" Column="26" TopLine="84"/>
+        <Filename Value="..\AufScript\aufscript_frame.pas"/>
+        <Caret Line="77" Column="13" TopLine="52"/>
       </Position25>
       <Position26>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="101" Column="103" TopLine="84"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="71" Column="5" TopLine="54"/>
       </Position26>
       <Position27>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="103" Column="17" TopLine="84"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="1719" Column="34" TopLine="1699"/>
       </Position27>
       <Position28>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="101" Column="36" TopLine="85"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2376" Column="17" TopLine="2367"/>
       </Position28>
       <Position29>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="63" Column="57" TopLine="46"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2077" Column="37" TopLine="2052"/>
       </Position29>
       <Position30>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="101" Column="114" TopLine="91"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2166" Column="43" TopLine="2152"/>
       </Position30>
     </JumpHistory>
   </ProjectSession>
@@ -1186,7 +1208,7 @@
         <Line Value="109"/>
       </Item4>
     </BreakPoints>
-    <Watches Count="3">
+    <Watches Count="4">
       <Item1>
         <Expression Value="regg"/>
       </Item1>
@@ -1196,6 +1218,9 @@
       <Item3>
         <Expression Value="Self"/>
       </Item3>
+      <Item4>
+        <Expression Value="FClass.ClassName"/>
+      </Item4>
     </Watches>
   </Debugging>
 </CONFIG>

--- a/RTFP_Desktop.lps
+++ b/RTFP_Desktop.lps
@@ -4,14 +4,15 @@
     <PathDelim Value="\"/>
     <Version Value="10"/>
     <BuildModes Active="Default"/>
-    <Units Count="121">
+    <Units Count="122">
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="-1"/>
+        <EditorIndex Value="18"/>
         <TopLine Value="2"/>
-        <CursorPos X="28" Y="27"/>
+        <CursorPos Y="37"/>
         <UsageCount Value="201"/>
+        <Loaded Value="True"/>
       </Unit0>
       <Unit1>
         <Filename Value="rtfp_main.pas"/>
@@ -20,8 +21,8 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="RTFP_main"/>
-        <TopLine Value="2270"/>
-        <CursorPos X="17" Y="2293"/>
+        <TopLine Value="770"/>
+        <CursorPos X="45" Y="788"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -32,7 +33,7 @@
         <ComponentName Value="Form_FileSource"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="29"/>
+        <EditorIndex Value="34"/>
         <TopLine Value="73"/>
         <CursorPos X="16" Y="87"/>
         <UsageCount Value="202"/>
@@ -42,7 +43,7 @@
       <Unit3>
         <Filename Value="sync\sync_timer.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="30"/>
+        <EditorIndex Value="35"/>
         <TopLine Value="7"/>
         <CursorPos X="16" Y="25"/>
         <UsageCount Value="200"/>
@@ -56,7 +57,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
       </Unit4>
       <Unit5>
         <Filename Value="forms\form_cite_trans.pas"/>
@@ -64,10 +65,10 @@
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="19"/>
+        <EditorIndex Value="24"/>
         <TopLine Value="136"/>
         <CursorPos X="13" Y="150"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit5>
@@ -77,10 +78,10 @@
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="28"/>
+        <EditorIndex Value="33"/>
         <TopLine Value="177"/>
         <CursorPos X="22" Y="192"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit6>
@@ -90,10 +91,10 @@
         <ComponentName Value="FormFieldDisplayOption"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="7"/>
+        <EditorIndex Value="10"/>
         <TopLine Value="40"/>
         <CursorPos X="10" Y="68"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit7>
@@ -105,7 +106,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
       </Unit8>
       <Unit9>
         <Filename Value="forms\form_import.pas"/>
@@ -114,7 +115,7 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
       </Unit9>
       <Unit10>
         <Filename Value="forms\form_new_project.pas"/>
@@ -122,10 +123,10 @@
         <ComponentName Value="Form_NewProject"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="10"/>
+        <EditorIndex Value="13"/>
         <TopLine Value="20"/>
         <CursorPos X="79" Y="31"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit10>
@@ -135,10 +136,10 @@
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="23"/>
-        <TopLine Value="194"/>
-        <CursorPos X="35" Y="215"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="28"/>
+        <TopLine Value="179"/>
+        <CursorPos X="24" Y="191"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit11>
@@ -150,14 +151,14 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
       </Unit12>
       <Unit13>
         <Filename Value="forms\form_repeated_checker.pas"/>
         <IsPartOfProject Value="True"/>
         <HasResources Value="True"/>
-        <EditorIndex Value="1"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="2"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit13>
       <Unit14>
@@ -166,82 +167,82 @@
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <IsVisibleTab Value="True"/>
-        <EditorIndex Value="27"/>
-        <TopLine Value="519"/>
-        <CursorPos X="35" Y="549"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="32"/>
+        <TopLine Value="432"/>
+        <CursorPos X="33" Y="452"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit14>
       <Unit15>
         <Filename Value="rtfp_core\rtfp_class.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="22"/>
-        <TopLine Value="189"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="27"/>
+        <CursorPos X="22" Y="74"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit15>
       <Unit16>
         <Filename Value="rtfp_core\rtfp_constants.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="25"/>
-        <CursorPos X="52" Y="34"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="30"/>
+        <TopLine Value="16"/>
+        <CursorPos X="3" Y="52"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit16>
       <Unit17>
         <Filename Value="rtfp_core\rtfp_definition.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="RTFP_definition"/>
-        <EditorIndex Value="14"/>
-        <TopLine Value="183"/>
-        <CursorPos X="15" Y="199"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="17"/>
+        <TopLine Value="306"/>
+        <CursorPos X="14" Y="324"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit17>
       <Unit18>
         <Filename Value="rtfp_core\rtfp_dialog.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="31"/>
+        <EditorIndex Value="36"/>
         <TopLine Value="598"/>
         <CursorPos X="18" Y="555"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit18>
       <Unit19>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="11"/>
+        <EditorIndex Value="14"/>
         <TopLine Value="414"/>
-        <CursorPos X="15" Y="195"/>
-        <UsageCount Value="170"/>
+        <CursorPos Y="415"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit19>
       <Unit20>
         <Filename Value="rtfp_core\rtfp_files.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="18"/>
+        <EditorIndex Value="23"/>
         <TopLine Value="79"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit20>
       <Unit21>
         <Filename Value="rtfp_core\rtfp_format_component.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="26"/>
-        <TopLine Value="81"/>
-        <CursorPos X="36" Y="102"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="31"/>
+        <TopLine Value="176"/>
+        <CursorPos X="37" Y="128"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit21>
       <Unit22>
         <Filename Value="rtfp_core\rtfp_misc.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="20"/>
-        <TopLine Value="22"/>
+        <EditorIndex Value="25"/>
+        <TopLine Value="67"/>
         <CursorPos Y="28"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit22>
       <Unit23>
@@ -251,48 +252,52 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="201"/>
       </Unit23>
       <Unit24>
         <Filename Value="rtfp_core\rtfp_type.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="21"/>
-        <UsageCount Value="170"/>
+        <EditorIndex Value="26"/>
+        <CursorPos X="46" Y="13"/>
+        <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit24>
       <Unit25>
         <Filename Value="rtfp_pdf\rtfp_pdfium.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="13"/>
+        <EditorIndex Value="16"/>
         <TopLine Value="108"/>
         <CursorPos X="29" Y="135"/>
-        <UsageCount Value="169"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit25>
       <Unit26>
         <Filename Value="rtfp_pdf\rtfp_pdfobj.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="12"/>
+        <EditorIndex Value="15"/>
         <TopLine Value="165"/>
         <CursorPos X="32" Y="173"/>
-        <UsageCount Value="169"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit26>
       <Unit27>
         <Filename Value="rtfp_core\formatedit_list.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="3"/>
-        <TopLine Value="55"/>
-        <CursorPos Y="162"/>
-        <UsageCount Value="165"/>
+        <IsVisibleTab Value="True"/>
+        <EditorIndex Value="4"/>
+        <TopLine Value="93"/>
+        <CursorPos X="64" Y="109"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit27>
       <Unit28>
         <Filename Value="rtfp_core\packed_format.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="48" Y="14"/>
-        <UsageCount Value="147"/>
+        <EditorIndex Value="1"/>
+        <TopLine Value="4"/>
+        <CursorPos X="34" Y="21"/>
+        <UsageCount Value="194"/>
+        <Loaded Value="True"/>
       </Unit28>
       <Unit29>
         <Filename Value="forms\form_field_change.pas"/>
@@ -300,56 +305,56 @@
         <ComponentName Value="Form_FieldChange"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="8"/>
+        <EditorIndex Value="11"/>
         <TopLine Value="94"/>
         <CursorPos X="3" Y="99"/>
-        <UsageCount Value="106"/>
+        <UsageCount Value="153"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit29>
       <Unit30>
         <Filename Value="rtfp_core\rtfp_field_convert.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="9"/>
+        <EditorIndex Value="12"/>
         <TopLine Value="79"/>
         <CursorPos X="40" Y="55"/>
-        <UsageCount Value="94"/>
+        <UsageCount Value="141"/>
         <Loaded Value="True"/>
       </Unit30>
       <Unit31>
         <Filename Value="rtfp_core\formatedit_component.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="2"/>
+        <EditorIndex Value="3"/>
         <TopLine Value="209"/>
         <CursorPos X="34" Y="227"/>
-        <UsageCount Value="105"/>
+        <UsageCount Value="152"/>
         <Loaded Value="True"/>
       </Unit31>
       <Unit32>
         <Filename Value="rtfp_core\access_field.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="16"/>
+        <EditorIndex Value="21"/>
         <TopLine Value="105"/>
         <CursorPos X="3" Y="111"/>
-        <UsageCount Value="104"/>
+        <UsageCount Value="151"/>
         <Loaded Value="True"/>
       </Unit32>
       <Unit33>
         <Filename Value="rtfp_core\control_interface.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="17"/>
-        <TopLine Value="253"/>
-        <CursorPos X="54" Y="271"/>
-        <UsageCount Value="104"/>
+        <EditorIndex Value="22"/>
+        <TopLine Value="322"/>
+        <CursorPos X="62" Y="341"/>
+        <UsageCount Value="151"/>
         <Loaded Value="True"/>
       </Unit33>
       <Unit34>
         <Filename Value="rtfp_core\access_data.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="4"/>
-        <TopLine Value="508"/>
-        <CursorPos X="19" Y="526"/>
-        <UsageCount Value="104"/>
+        <EditorIndex Value="5"/>
+        <TopLine Value="238"/>
+        <CursorPos X="46" Y="285"/>
+        <UsageCount Value="151"/>
         <Loaded Value="True"/>
       </Unit34>
       <Unit35>
@@ -358,40 +363,39 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="393"/>
         <CursorPos X="39" Y="415"/>
-        <UsageCount Value="98"/>
+        <UsageCount Value="145"/>
       </Unit35>
       <Unit36>
         <Filename Value="rtfp_core\aufunc.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="5"/>
-        <TopLine Value="235"/>
-        <CursorPos Y="253"/>
-        <UsageCount Value="90"/>
+        <EditorIndex Value="6"/>
+        <CursorPos X="30" Y="122"/>
+        <UsageCount Value="137"/>
         <Loaded Value="True"/>
       </Unit36>
       <Unit37>
         <Filename Value="rtfp_core\access_base.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="6"/>
-        <TopLine Value="307"/>
-        <CursorPos X="29" Y="405"/>
-        <UsageCount Value="79"/>
+        <EditorIndex Value="9"/>
+        <TopLine Value="256"/>
+        <CursorPos X="27" Y="300"/>
+        <UsageCount Value="126"/>
         <Loaded Value="True"/>
       </Unit37>
       <Unit38>
         <Filename Value="rtfp_core\events.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="15"/>
+        <EditorIndex Value="20"/>
         <CursorPos Y="19"/>
-        <UsageCount Value="75"/>
+        <UsageCount Value="122"/>
         <Loaded Value="True"/>
       </Unit38>
       <Unit39>
         <Filename Value="rtfp_core\access_attrs.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="24"/>
+        <EditorIndex Value="29"/>
         <CursorPos X="27" Y="16"/>
-        <UsageCount Value="63"/>
+        <UsageCount Value="110"/>
         <Loaded Value="True"/>
       </Unit39>
       <Unit40>
@@ -401,7 +405,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="63"/>
+        <UsageCount Value="110"/>
       </Unit40>
       <Unit41>
         <Filename Value="rtfp_core\image.inc"/>
@@ -410,7 +414,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="63"/>
+        <UsageCount Value="110"/>
       </Unit41>
       <Unit42>
         <Filename Value="rtfp_core\notes.inc"/>
@@ -419,16 +423,16 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="63"/>
+        <UsageCount Value="110"/>
       </Unit42>
       <Unit43>
         <Filename Value="rtfp_core\paper.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="-1"/>
-        <WindowIndex Value="-1"/>
-        <TopLine Value="-1"/>
-        <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="63"/>
+        <EditorIndex Value="19"/>
+        <TopLine Value="458"/>
+        <CursorPos Y="465"/>
+        <UsageCount Value="110"/>
+        <Loaded Value="True"/>
       </Unit43>
       <Unit44>
         <Filename Value="rtfp_core\tags.inc"/>
@@ -437,7 +441,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="63"/>
+        <UsageCount Value="110"/>
       </Unit44>
       <Unit45>
         <Filename Value="rtfp_core\update.inc"/>
@@ -446,7 +450,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="63"/>
+        <UsageCount Value="110"/>
       </Unit45>
       <Unit46>
         <Filename Value="..\FPC_Unit\Auf\aufscript_frame.pas"/>
@@ -455,27 +459,27 @@
         <ResourceBaseClass Value="Frame"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="82" Y="9"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="180"/>
       </Unit46>
       <Unit47>
         <Filename Value="..\FPC_Unit\Auf\synhighlighterauf.pas"/>
         <UnitName Value="SynHighlighterAuf"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="19"/>
+        <UsageCount Value="15"/>
       </Unit47>
       <Unit48>
         <Filename Value="rtfp_pdfium.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="164"/>
         <CursorPos X="60" Y="191"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="186"/>
       </Unit48>
       <Unit49>
         <Filename Value="rtfp_pdfobj.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="217"/>
         <CursorPos X="73" Y="217"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit49>
       <Unit50>
         <Filename Value="rtfp_definition.pas"/>
@@ -483,69 +487,69 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="230"/>
         <CursorPos X="14" Y="242"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="185"/>
       </Unit50>
       <Unit51>
         <Filename Value="rtfp_field.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="76"/>
         <CursorPos X="15" Y="90"/>
-        <UsageCount Value="194"/>
+        <UsageCount Value="190"/>
       </Unit51>
       <Unit52>
         <Filename Value="rtfp_class.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
         <CursorPos X="15" Y="17"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="186"/>
       </Unit52>
       <Unit53>
         <Filename Value="rtfp_files.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="74"/>
         <CursorPos X="45" Y="77"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="185"/>
       </Unit53>
       <Unit54>
         <Filename Value="rtfp_constants.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="42" Y="15"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="186"/>
       </Unit54>
       <Unit55>
         <Filename Value="rtfp_format_component.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="503"/>
         <CursorPos X="48" Y="506"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="185"/>
       </Unit55>
       <Unit56>
         <Filename Value="rtfp_tags.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="46" Y="155"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit56>
       <Unit57>
         <Filename Value="rtfp_misc.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="20" Y="33"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit57>
       <Unit58>
         <Filename Value="rtfp_dialog.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="43" Y="40"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="186"/>
       </Unit58>
       <Unit59>
         <Filename Value="rtfp_type.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6"/>
         <CursorPos X="30" Y="28"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="186"/>
       </Unit59>
       <Unit60>
         <Filename Value="form_new_project.pas"/>
@@ -555,7 +559,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="91"/>
         <CursorPos X="54" Y="108"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit60>
       <Unit61>
         <Filename Value="form_cite_trans.pas"/>
@@ -565,7 +569,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="35"/>
         <CursorPos X="90" Y="39"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit61>
       <Unit62>
         <Filename Value="form_import.pas"/>
@@ -575,7 +579,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="264"/>
         <CursorPos X="96" Y="265"/>
-        <UsageCount Value="195"/>
+        <UsageCount Value="191"/>
       </Unit62>
       <Unit63>
         <Filename Value="form_classmanager.pas"/>
@@ -585,7 +589,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="81" Y="27"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="185"/>
       </Unit63>
       <Unit64>
         <Filename Value="form_appearance.pas"/>
@@ -594,7 +598,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="102" Y="3"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="185"/>
       </Unit64>
       <Unit65>
         <Filename Value="form_options.pas"/>
@@ -604,7 +608,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="41"/>
         <CursorPos X="42" Y="43"/>
-        <UsageCount Value="191"/>
+        <UsageCount Value="187"/>
       </Unit65>
       <Unit66>
         <Filename Value="form_report_tool.pas"/>
@@ -614,7 +618,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="20"/>
         <CursorPos X="74" Y="22"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit66>
       <Unit67>
         <Filename Value="form_repeated_checker.pas"/>
@@ -624,7 +628,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="291"/>
         <CursorPos X="46" Y="292"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit67>
       <Unit68>
         <Filename Value="form_project_profile.pas"/>
@@ -633,7 +637,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="55" Y="4"/>
-        <UsageCount Value="189"/>
+        <UsageCount Value="185"/>
       </Unit68>
       <Unit69>
         <Filename Value="form_field_display_option.pas"/>
@@ -643,7 +647,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="46"/>
         <CursorPos X="65" Y="49"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit69>
       <Unit70>
         <Filename Value="form_formatedit_option.pas"/>
@@ -653,26 +657,27 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="130"/>
         <CursorPos X="15" Y="121"/>
-        <UsageCount Value="191"/>
+        <UsageCount Value="187"/>
       </Unit70>
       <Unit71>
         <Filename Value="..\AufScript\aufscript_frame.pas"/>
         <ComponentName Value="Frame_AufScript"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Frame"/>
-        <EditorIndex Value="-1"/>
-        <WindowIndex Value="-1"/>
-        <TopLine Value="-1"/>
-        <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="188"/>
+        <EditorIndex Value="8"/>
+        <TopLine Value="87"/>
+        <CursorPos Y="107"/>
+        <UsageCount Value="185"/>
+        <Loaded Value="True"/>
       </Unit71>
       <Unit72>
         <Filename Value="..\AufScript\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="3079"/>
-        <CursorPos X="49" Y="3090"/>
-        <UsageCount Value="188"/>
+        <EditorIndex Value="7"/>
+        <TopLine Value="4585"/>
+        <CursorPos X="3" Y="4616"/>
+        <UsageCount Value="185"/>
+        <Loaded Value="True"/>
       </Unit72>
       <Unit73>
         <Filename Value="..\AufScript\auf_ram_var.pas"/>
@@ -680,13 +685,13 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="188"/>
+        <UsageCount Value="184"/>
       </Unit73>
       <Unit74>
         <Filename Value="..\FPC_Unit\Auf\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="170"/>
       </Unit74>
       <Unit75>
         <Filename Value="..\FPC_Unit\ACL\ListViewEx\acl_listview.pas"/>
@@ -694,14 +699,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="34"/>
         <CursorPos Y="66"/>
-        <UsageCount Value="73"/>
+        <UsageCount Value="69"/>
       </Unit75>
       <Unit76>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\systemh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1119"/>
         <CursorPos X="11" Y="1136"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="4"/>
       </Unit76>
       <Unit77>
         <Filename Value="D:\Lazarus\lcl\stdctrls.pp"/>
@@ -709,431 +714,445 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="483"/>
         <CursorPos X="3" Y="497"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="4"/>
       </Unit77>
       <Unit78>
-        <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\filutilh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="142"/>
-        <CursorPos X="10" Y="156"/>
-        <UsageCount Value="2"/>
-      </Unit78>
-      <Unit79>
-        <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\filutil.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="276"/>
-        <CursorPos X="3" Y="278"/>
-        <UsageCount Value="2"/>
-      </Unit79>
-      <Unit80>
-        <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\sysutils.pp"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="552"/>
-        <CursorPos X="3" Y="557"/>
-        <UsageCount Value="2"/>
-      </Unit80>
-      <Unit81>
-        <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\unifun.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="110"/>
-        <CursorPos X="10" Y="124"/>
-        <UsageCount Value="2"/>
-      </Unit81>
-      <Unit82>
-        <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysunih.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="36"/>
-        <CursorPos X="10" Y="49"/>
-        <UsageCount Value="2"/>
-      </Unit82>
-      <Unit83>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="1823"/>
-        <CursorPos X="17" Y="1840"/>
-        <UsageCount Value="7"/>
-      </Unit83>
-      <Unit84>
+        <TopLine Value="1752"/>
+        <CursorPos X="3" Y="1770"/>
+        <UsageCount Value="9"/>
+      </Unit78>
+      <Unit79>
         <Filename Value="C:\lazarus\lcl\include\picture.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="560"/>
         <CursorPos X="11" Y="577"/>
-        <UsageCount Value="10"/>
-      </Unit84>
-      <Unit85>
+        <UsageCount Value="6"/>
+      </Unit79>
+      <Unit80>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="883"/>
-        <CursorPos X="3" Y="871"/>
-        <UsageCount Value="10"/>
-      </Unit85>
-      <Unit86>
+        <TopLine Value="1924"/>
+        <CursorPos X="3" Y="1942"/>
+        <UsageCount Value="9"/>
+      </Unit80>
+      <Unit81>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\bufdataset.pas"/>
         <UnitName Value="BufDataset"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="596"/>
-        <CursorPos X="3" Y="616"/>
-        <UsageCount Value="9"/>
-      </Unit86>
-      <Unit87>
+        <TopLine Value="582"/>
+        <CursorPos X="29" Y="612"/>
+        <UsageCount Value="8"/>
+      </Unit81>
+      <Unit82>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="485"/>
         <CursorPos X="17" Y="497"/>
-        <UsageCount Value="4"/>
-      </Unit87>
-      <Unit88>
+        <UsageCount Value="10"/>
+      </Unit82>
+      <Unit83>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\ascdef.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="102"/>
         <CursorPos X="10" Y="122"/>
-        <UsageCount Value="8"/>
-      </Unit88>
-      <Unit89>
+        <UsageCount Value="4"/>
+      </Unit83>
+      <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win64\system.pp"/>
         <UnitName Value="System"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="121"/>
         <CursorPos Y="16"/>
-        <UsageCount Value="8"/>
-      </Unit89>
-      <Unit90>
+        <UsageCount Value="4"/>
+      </Unit84>
+      <Unit85>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\system.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="73"/>
         <CursorPos X="34" Y="10"/>
-        <UsageCount Value="8"/>
-      </Unit90>
-      <Unit91>
+        <UsageCount Value="4"/>
+      </Unit85>
+      <Unit86>
         <Filename Value="data_access.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="449"/>
         <CursorPos X="3" Y="32"/>
-        <UsageCount Value="8"/>
-      </Unit91>
-      <Unit92>
+        <UsageCount Value="4"/>
+      </Unit86>
+      <Unit87>
         <Filename Value="formatedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="141"/>
         <CursorPos X="68" Y="263"/>
-        <UsageCount Value="8"/>
-      </Unit92>
-      <Unit93>
-        <Filename Value="aufunc.inc"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="48" Y="11"/>
-        <UsageCount Value="1"/>
-      </Unit93>
-      <Unit94>
-        <Filename Value="update.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="80"/>
-        <CursorPos Y="81"/>
-        <UsageCount Value="2"/>
-      </Unit94>
-      <Unit95>
+        <UsageCount Value="4"/>
+      </Unit87>
+      <Unit88>
         <Filename Value="papers.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="54" Y="4"/>
-        <UsageCount Value="8"/>
-      </Unit95>
-      <Unit96>
-        <Filename Value="notes.inc"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="19" Y="3"/>
-        <UsageCount Value="1"/>
-      </Unit96>
-      <Unit97>
-        <Filename Value="image.inc"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos Y="3"/>
-        <UsageCount Value="1"/>
-      </Unit97>
-      <Unit98>
+        <UsageCount Value="4"/>
+      </Unit88>
+      <Unit89>
         <Filename Value="events.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21" Y="10"/>
-        <UsageCount Value="8"/>
-      </Unit98>
-      <Unit99>
+        <UsageCount Value="4"/>
+      </Unit89>
+      <Unit90>
         <Filename Value="tags.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="32" Y="10"/>
-        <UsageCount Value="8"/>
-      </Unit99>
-      <Unit100>
+        <UsageCount Value="4"/>
+      </Unit90>
+      <Unit91>
         <Filename Value="paper.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="5" Y="3"/>
-        <UsageCount Value="8"/>
-      </Unit100>
-      <Unit101>
-        <Filename Value="control_interface.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="442"/>
-        <CursorPos X="14" Y="49"/>
-        <UsageCount Value="1"/>
-      </Unit101>
-      <Unit102>
+        <UsageCount Value="4"/>
+      </Unit91>
+      <Unit92>
         <Filename Value="cite_tool.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="667"/>
         <CursorPos X="40" Y="679"/>
-        <UsageCount Value="10"/>
-      </Unit102>
-      <Unit103>
+        <UsageCount Value="6"/>
+      </Unit92>
+      <Unit93>
         <Filename Value="forms\form_classmanager.lfm"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="4"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
-      </Unit103>
-      <Unit104>
+      </Unit93>
+      <Unit94>
         <Filename Value="D:\Lazarus\components\synedit\synhighlighterunixshellscript.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="70"/>
         <CursorPos X="25" Y="73"/>
-        <UsageCount Value="8"/>
-      </Unit104>
-      <Unit105>
+        <UsageCount Value="4"/>
+      </Unit94>
+      <Unit95>
         <Filename Value="C:\lazarus\lcl\dbgrids.pas"/>
         <UnitName Value="DBGrids"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="535"/>
         <CursorPos X="25" Y="563"/>
-        <UsageCount Value="8"/>
-      </Unit105>
-      <Unit106>
+        <UsageCount Value="4"/>
+      </Unit95>
+      <Unit96>
         <Filename Value="C:\lazarus\lcl\include\customedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="81"/>
         <CursorPos Y="100"/>
-        <UsageCount Value="4"/>
-      </Unit106>
-      <Unit107>
+        <UsageCount Value="10"/>
+      </Unit96>
+      <Unit97>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\fields.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="38"/>
         <CursorPos Y="42"/>
-        <UsageCount Value="4"/>
-      </Unit107>
-      <Unit108>
+        <UsageCount Value="10"/>
+      </Unit97>
+      <Unit98>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\registry.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="79"/>
         <CursorPos X="25" Y="104"/>
-        <UsageCount Value="10"/>
-      </Unit108>
-      <Unit109>
+        <UsageCount Value="6"/>
+      </Unit98>
+      <Unit99>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\winreg.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="167"/>
         <CursorPos X="3" Y="172"/>
-        <UsageCount Value="10"/>
-      </Unit109>
-      <Unit110>
+        <UsageCount Value="6"/>
+      </Unit99>
+      <Unit100>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\win\wininc\func.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="931"/>
         <CursorPos X="10" Y="949"/>
-        <UsageCount Value="7"/>
-      </Unit110>
-      <Unit111>
+        <UsageCount Value="3"/>
+      </Unit100>
+      <Unit101>
         <Filename Value="C:\lazarus\lcl\include\customform.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2935"/>
         <CursorPos Y="2962"/>
-        <UsageCount Value="7"/>
-      </Unit111>
-      <Unit112>
+        <UsageCount Value="3"/>
+      </Unit101>
+      <Unit102>
         <Filename Value="C:\lazarus\lcl\forms.pp"/>
         <UnitName Value="Forms"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="629"/>
-        <CursorPos X="14" Y="645"/>
-        <UsageCount Value="7"/>
-      </Unit112>
-      <Unit113>
+        <TopLine Value="602"/>
+        <CursorPos X="3" Y="739"/>
+        <UsageCount Value="9"/>
+      </Unit102>
+      <Unit103>
         <Filename Value="C:\lazarus\lcl\include\control.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="1553"/>
-        <CursorPos Y="1573"/>
-        <UsageCount Value="7"/>
-      </Unit113>
-      <Unit114>
+        <TopLine Value="2236"/>
+        <CursorPos Y="2253"/>
+        <UsageCount Value="9"/>
+      </Unit103>
+      <Unit104>
         <Filename Value="C:\lazarus\lcl\include\wincontrol.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="5380"/>
-        <CursorPos X="39" Y="5399"/>
-        <UsageCount Value="7"/>
-      </Unit114>
-      <Unit115>
+        <TopLine Value="5381"/>
+        <CursorPos Y="5398"/>
+        <UsageCount Value="9"/>
+      </Unit104>
+      <Unit105>
         <Filename Value="C:\lazarus\lcl\include\fpimagebitmap.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="123"/>
         <CursorPos Y="141"/>
-        <UsageCount Value="8"/>
-      </Unit115>
-      <Unit116>
+        <UsageCount Value="4"/>
+      </Unit105>
+      <Unit106>
         <Filename Value="C:\lazarus\lcl\extctrls.pp"/>
         <UnitName Value="ExtCtrls"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1035"/>
         <CursorPos X="17" Y="1053"/>
-        <UsageCount Value="8"/>
-      </Unit116>
-      <Unit117>
+        <UsageCount Value="4"/>
+      </Unit106>
+      <Unit107>
         <Filename Value="C:\lazarus\lcl\graphics.pp"/>
         <UnitName Value="Graphics"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="679"/>
         <CursorPos X="3" Y="698"/>
-        <UsageCount Value="18"/>
-      </Unit117>
-      <Unit118>
+        <UsageCount Value="14"/>
+      </Unit107>
+      <Unit108>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\regexpr\src\regexpr.pas"/>
         <UnitName Value="RegExpr"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="416"/>
         <CursorPos X="33" Y="298"/>
-        <UsageCount Value="10"/>
-      </Unit118>
-      <Unit119>
+        <UsageCount Value="6"/>
+      </Unit108>
+      <Unit109>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysunih.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="34"/>
-        <CursorPos X="10" Y="17"/>
-        <UsageCount Value="9"/>
-      </Unit119>
-      <Unit120>
+        <TopLine Value="19"/>
+        <CursorPos X="10" Y="48"/>
+        <UsageCount Value="10"/>
+      </Unit109>
+      <Unit110>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-image\src\fpcanvas.pp"/>
         <UnitName Value="FPCanvas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="36" Y="158"/>
+        <UsageCount Value="6"/>
+      </Unit110>
+      <Unit111>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\memds\memds.pp"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="127"/>
+        <CursorPos X="74" Y="154"/>
+        <UsageCount Value="8"/>
+      </Unit111>
+      <Unit112>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysuni.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="267"/>
+        <CursorPos X="5" Y="277"/>
+        <UsageCount Value="9"/>
+      </Unit112>
+      <Unit113>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\lists.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="297"/>
+        <CursorPos Y="306"/>
+        <UsageCount Value="9"/>
+      </Unit113>
+      <Unit114>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\sqldb\sqldb.pp"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="576"/>
+        <CursorPos X="14" Y="593"/>
+        <UsageCount Value="9"/>
+      </Unit114>
+      <Unit115>
+        <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\database.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="21"/>
+        <CursorPos Y="21"/>
         <UsageCount Value="10"/>
+      </Unit115>
+      <Unit116>
+        <Filename Value="C:\lazarus\lcl\stdctrls.pp"/>
+        <UnitName Value="StdCtrls"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="704"/>
+        <CursorPos X="30" Y="727"/>
+        <UsageCount Value="9"/>
+      </Unit116>
+      <Unit117>
+        <Filename Value="C:\lazarus\lcl\controls.pp"/>
+        <UnitName Value="Controls"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="1914"/>
+        <CursorPos X="36" Y="1936"/>
+        <UsageCount Value="9"/>
+      </Unit117>
+      <Unit118>
+        <Filename Value="C:\lazarus\lcl\lclclasses.pp"/>
+        <UnitName Value="LCLClasses"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="24"/>
+        <CursorPos X="3" Y="42"/>
+        <UsageCount Value="9"/>
+      </Unit118>
+      <Unit119>
+        <Filename Value="..\ACL_ListView\acl_listview.pas"/>
+        <UnitName Value="ACL_ListView"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="13"/>
+        <UsageCount Value="9"/>
+      </Unit119>
+      <Unit120>
+        <Filename Value="C:\lazarus\lcl\lclmessageglue.pas"/>
+        <UnitName Value="LCLMessageGlue"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="95"/>
+        <CursorPos Y="112"/>
+        <UsageCount Value="9"/>
       </Unit120>
+      <Unit121>
+        <Filename Value="C:\lazarus\lcl\interfaces\win32\win32callback.inc"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="2652"/>
+        <CursorPos Y="2671"/>
+        <UsageCount Value="9"/>
+      </Unit121>
     </Units>
-    <JumpHistory Count="30" HistoryIndex="28">
+    <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="216" TopLine="196"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="211" TopLine="196"/>
       </Position1>
       <Position2>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="213" Column="37" TopLine="199"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="213" TopLine="196"/>
       </Position2>
       <Position3>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="178" Column="5" TopLine="159"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="198" TopLine="191"/>
       </Position3>
       <Position4>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="213" Column="28" TopLine="202"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="195" TopLine="188"/>
       </Position4>
       <Position5>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="214" Column="74" TopLine="197"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="190" TopLine="182"/>
       </Position5>
       <Position6>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="212" TopLine="197"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="220" TopLine="196"/>
       </Position6>
       <Position7>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="213" TopLine="197"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="771" TopLine="760"/>
       </Position7>
       <Position8>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="206" Column="14" TopLine="197"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="773" TopLine="760"/>
       </Position8>
       <Position9>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="212" TopLine="197"/>
+        <Filename Value="rtfp_core\access_base.inc"/>
+        <Caret Line="271" TopLine="261"/>
       </Position9>
       <Position10>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="213" Column="28" TopLine="197"/>
+        <Filename Value="rtfp_core\access_base.inc"/>
+        <Caret Line="272" TopLine="273"/>
       </Position10>
       <Position11>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="212" TopLine="197"/>
+        <Filename Value="rtfp_core\access_base.inc"/>
+        <Caret Line="273" TopLine="255"/>
       </Position11>
       <Position12>
-        <Filename Value="forms\form_options.pas"/>
-        <Caret Line="213" TopLine="197"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="773" TopLine="760"/>
       </Position12>
       <Position13>
-        <Filename Value="rtfp_core\formatedit_component.inc"/>
-        <Caret Line="249" Column="73" TopLine="231"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="704" Column="29" TopLine="688"/>
       </Position13>
       <Position14>
-        <Filename Value="rtfp_core\aufunc.inc"/>
-        <Caret Line="4"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="143" Column="15" TopLine="126"/>
       </Position14>
       <Position15>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="444" Column="16" TopLine="433"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="415" Column="70" TopLine="411"/>
       </Position15>
       <Position16>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="226" Column="48" TopLine="217"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="135" Column="14" TopLine="117"/>
       </Position16>
       <Position17>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="226" Column="48" TopLine="217"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="53" Column="17" TopLine="33"/>
       </Position17>
       <Position18>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="308" Column="46" TopLine="286"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="770" Column="21" TopLine="757"/>
       </Position18>
       <Position19>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="489" Column="37" TopLine="468"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="372" Column="30" TopLine="363"/>
       </Position19>
       <Position20>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="337" Column="39" TopLine="324"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="62" Column="25" TopLine="45"/>
       </Position20>
       <Position21>
-        <Filename Value="rtfp_main.pas"/>
-        <Caret Line="2289" Column="80" TopLine="2259"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="143" Column="24" TopLine="122"/>
       </Position21>
       <Position22>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="434" Column="39" TopLine="419"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="776" Column="21" TopLine="760"/>
       </Position22>
       <Position23>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="51" Column="12" TopLine="110"/>
+        <Filename Value="rtfp_core\formatedit_list.inc"/>
+        <Caret Line="162" TopLine="55"/>
       </Position23>
       <Position24>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="531" TopLine="523"/>
+        <Filename Value="rtfp_core\formatedit_list.inc"/>
+        <Caret Line="109" Column="43" TopLine="85"/>
       </Position24>
       <Position25>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="49" Column="38"/>
+        <Filename Value="rtfp_core\formatedit_list.inc"/>
+        <Caret Line="93" TopLine="13"/>
       </Position25>
       <Position26>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="554" TopLine="524"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="324" Column="38" TopLine="306"/>
       </Position26>
       <Position27>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="57" Column="23" TopLine="38"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="1168" Column="17" TopLine="1207"/>
       </Position27>
       <Position28>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="488" Column="12" TopLine="385"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="330" Column="15" TopLine="313"/>
       </Position28>
       <Position29>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="505" Column="3" TopLine="500"/>
+        <Filename Value="rtfp_core\formatedit_list.inc"/>
+        <Caret Line="194" Column="35" TopLine="172"/>
       </Position29>
       <Position30>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="561" Column="3" TopLine="529"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="324" Column="14" TopLine="306"/>
       </Position30>
     </JumpHistory>
   </ProjectSession>
@@ -1168,10 +1187,13 @@
         <Line Value="109"/>
       </Item4>
     </BreakPoints>
-    <Watches Count="1">
+    <Watches Count="2">
       <Item1>
         <Expression Value="regg"/>
       </Item1>
+      <Item2>
+        <Expression Value="dbf_name_no_ext"/>
+      </Item2>
     </Watches>
   </Debugging>
 </CONFIG>

--- a/RTFP_Desktop.lps
+++ b/RTFP_Desktop.lps
@@ -8,7 +8,7 @@
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="20"/>
+        <EditorIndex Value="21"/>
         <TopLine Value="3"/>
         <CursorPos Y="20"/>
         <UsageCount Value="201"/>
@@ -21,7 +21,8 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="RTFP_main"/>
-        <CursorPos X="18" Y="72"/>
+        <TopLine Value="2412"/>
+        <CursorPos X="44" Y="2432"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -32,7 +33,7 @@
         <ComponentName Value="Form_FileSource"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="36"/>
+        <EditorIndex Value="37"/>
         <TopLine Value="73"/>
         <CursorPos X="16" Y="87"/>
         <UsageCount Value="202"/>
@@ -42,7 +43,7 @@
       <Unit3>
         <Filename Value="sync\sync_timer.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="37"/>
+        <EditorIndex Value="38"/>
         <TopLine Value="7"/>
         <CursorPos X="16" Y="25"/>
         <UsageCount Value="200"/>
@@ -64,7 +65,7 @@
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="26"/>
+        <EditorIndex Value="27"/>
         <TopLine Value="136"/>
         <CursorPos X="13" Y="150"/>
         <UsageCount Value="201"/>
@@ -77,7 +78,7 @@
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="35"/>
+        <EditorIndex Value="36"/>
         <TopLine Value="177"/>
         <CursorPos X="28" Y="190"/>
         <UsageCount Value="201"/>
@@ -92,7 +93,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="10"/>
         <TopLine Value="40"/>
-        <CursorPos X="10" Y="68"/>
+        <CursorPos X="35" Y="54"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -100,12 +101,14 @@
       <Unit8>
         <Filename Value="forms\form_formatedit_option.pas"/>
         <IsPartOfProject Value="True"/>
+        <ComponentName Value="FormFormatEditOption"/>
         <HasResources Value="True"/>
-        <EditorIndex Value="-1"/>
-        <WindowIndex Value="-1"/>
-        <TopLine Value="-1"/>
-        <CursorPos X="-1" Y="-1"/>
+        <ResourceBaseClass Value="Form"/>
+        <EditorIndex Value="11"/>
+        <CursorPos X="30" Y="21"/>
         <UsageCount Value="201"/>
+        <Loaded Value="True"/>
+        <LoadedDesigner Value="True"/>
       </Unit8>
       <Unit9>
         <Filename Value="forms\form_import.pas"/>
@@ -122,7 +125,7 @@
         <ComponentName Value="Form_NewProject"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="13"/>
+        <EditorIndex Value="14"/>
         <TopLine Value="20"/>
         <CursorPos X="79" Y="31"/>
         <UsageCount Value="201"/>
@@ -135,9 +138,9 @@
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="30"/>
-        <TopLine Value="179"/>
-        <CursorPos X="24" Y="191"/>
+        <EditorIndex Value="31"/>
+        <TopLine Value="13"/>
+        <CursorPos X="30" Y="33"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -166,7 +169,7 @@
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="34"/>
+        <EditorIndex Value="35"/>
         <TopLine Value="405"/>
         <CursorPos X="11" Y="420"/>
         <UsageCount Value="201"/>
@@ -176,16 +179,17 @@
       <Unit15>
         <Filename Value="rtfp_core\rtfp_class.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="29"/>
-        <TopLine Value="101"/>
-        <CursorPos X="7" Y="201"/>
+        <EditorIndex Value="30"/>
+        <TopLine Value="173"/>
+        <CursorPos X="16" Y="198"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit15>
       <Unit16>
         <Filename Value="rtfp_core\rtfp_constants.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="32"/>
+        <EditorIndex Value="33"/>
+        <TopLine Value="3"/>
         <CursorPos X="43" Y="42"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -194,16 +198,17 @@
         <Filename Value="rtfp_core\rtfp_definition.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="RTFP_definition"/>
-        <EditorIndex Value="17"/>
-        <TopLine Value="37"/>
-        <CursorPos X="31" Y="23"/>
+        <IsVisibleTab Value="True"/>
+        <EditorIndex Value="18"/>
+        <TopLine Value="19"/>
+        <CursorPos X="49" Y="41"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit17>
       <Unit18>
         <Filename Value="rtfp_core\rtfp_dialog.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="38"/>
+        <EditorIndex Value="39"/>
         <TopLine Value="307"/>
         <CursorPos Y="127"/>
         <UsageCount Value="201"/>
@@ -212,31 +217,32 @@
       <Unit19>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="14"/>
-        <TopLine Value="46"/>
-        <CursorPos X="57" Y="63"/>
+        <EditorIndex Value="15"/>
+        <TopLine Value="81"/>
+        <CursorPos Y="97"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit19>
       <Unit20>
         <Filename Value="rtfp_core\rtfp_files.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="25"/>
+        <EditorIndex Value="26"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit20>
       <Unit21>
         <Filename Value="rtfp_core\rtfp_format_component.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="33"/>
-        <CursorPos X="33" Y="29"/>
+        <EditorIndex Value="34"/>
+        <TopLine Value="480"/>
+        <CursorPos X="118" Y="508"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit21>
       <Unit22>
         <Filename Value="rtfp_core\rtfp_misc.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="27"/>
+        <EditorIndex Value="28"/>
         <TopLine Value="67"/>
         <CursorPos Y="28"/>
         <UsageCount Value="201"/>
@@ -254,14 +260,16 @@
       <Unit24>
         <Filename Value="rtfp_core\rtfp_type.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="28"/>
+        <EditorIndex Value="29"/>
+        <TopLine Value="3"/>
+        <CursorPos X="11" Y="30"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit24>
       <Unit25>
         <Filename Value="rtfp_pdf\rtfp_pdfium.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="16"/>
+        <EditorIndex Value="17"/>
         <TopLine Value="108"/>
         <CursorPos X="29" Y="135"/>
         <UsageCount Value="200"/>
@@ -270,7 +278,7 @@
       <Unit26>
         <Filename Value="rtfp_pdf\rtfp_pdfobj.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="15"/>
+        <EditorIndex Value="16"/>
         <TopLine Value="165"/>
         <CursorPos X="32" Y="173"/>
         <UsageCount Value="200"/>
@@ -300,9 +308,9 @@
         <ComponentName Value="Form_FieldChange"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="11"/>
-        <TopLine Value="94"/>
-        <CursorPos X="37" Y="117"/>
+        <EditorIndex Value="12"/>
+        <TopLine Value="97"/>
+        <CursorPos X="24" Y="114"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -310,7 +318,7 @@
       <Unit30>
         <Filename Value="rtfp_core\rtfp_field_convert.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="12"/>
+        <EditorIndex Value="13"/>
         <TopLine Value="79"/>
         <CursorPos X="40" Y="55"/>
         <UsageCount Value="201"/>
@@ -320,15 +328,15 @@
         <Filename Value="rtfp_core\formatedit_component.inc"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="4"/>
-        <TopLine Value="79"/>
-        <CursorPos X="53" Y="100"/>
+        <TopLine Value="80"/>
+        <CursorPos X="45" Y="96"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit31>
       <Unit32>
         <Filename Value="rtfp_core\access_field.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="23"/>
+        <EditorIndex Value="24"/>
         <TopLine Value="228"/>
         <CursorPos X="39" Y="248"/>
         <UsageCount Value="200"/>
@@ -337,9 +345,9 @@
       <Unit33>
         <Filename Value="rtfp_core\control_interface.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="24"/>
-        <TopLine Value="486"/>
-        <CursorPos X="27" Y="493"/>
+        <EditorIndex Value="25"/>
+        <TopLine Value="103"/>
+        <CursorPos X="16" Y="121"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit33>
@@ -381,7 +389,7 @@
       <Unit38>
         <Filename Value="rtfp_core\events.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="22"/>
+        <EditorIndex Value="23"/>
         <CursorPos X="66" Y="17"/>
         <UsageCount Value="205"/>
         <Loaded Value="True"/>
@@ -389,7 +397,7 @@
       <Unit39>
         <Filename Value="rtfp_core\access_attrs.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="31"/>
+        <EditorIndex Value="32"/>
         <CursorPos X="27" Y="16"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
@@ -424,7 +432,7 @@
       <Unit43>
         <Filename Value="rtfp_core\paper.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="18"/>
+        <EditorIndex Value="19"/>
         <TopLine Value="458"/>
         <CursorPos X="16" Y="464"/>
         <UsageCount Value="200"/>
@@ -451,11 +459,10 @@
       <Unit46>
         <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
         <IsPartOfProject Value="True"/>
-        <IsVisibleTab Value="True"/>
-        <EditorIndex Value="19"/>
-        <TopLine Value="191"/>
-        <CursorPos X="20" Y="211"/>
-        <UsageCount Value="89"/>
+        <EditorIndex Value="20"/>
+        <TopLine Value="146"/>
+        <CursorPos X="44" Y="168"/>
+        <UsageCount Value="101"/>
         <Loaded Value="True"/>
       </Unit46>
       <Unit47>
@@ -465,27 +472,27 @@
         <ResourceBaseClass Value="Frame"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="82" Y="9"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="169"/>
       </Unit47>
       <Unit48>
         <Filename Value="..\FPC_Unit\Auf\synhighlighterauf.pas"/>
         <UnitName Value="SynHighlighterAuf"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit48>
       <Unit49>
         <Filename Value="rtfp_pdfium.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="164"/>
         <CursorPos X="60" Y="191"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit49>
       <Unit50>
         <Filename Value="rtfp_pdfobj.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="217"/>
         <CursorPos X="73" Y="217"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit50>
       <Unit51>
         <Filename Value="rtfp_definition.pas"/>
@@ -493,69 +500,69 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="230"/>
         <CursorPos X="14" Y="242"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit51>
       <Unit52>
         <Filename Value="rtfp_field.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="76"/>
         <CursorPos X="15" Y="90"/>
-        <UsageCount Value="180"/>
+        <UsageCount Value="179"/>
       </Unit52>
       <Unit53>
         <Filename Value="rtfp_class.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
         <CursorPos X="15" Y="17"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit53>
       <Unit54>
         <Filename Value="rtfp_files.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="74"/>
         <CursorPos X="45" Y="77"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit54>
       <Unit55>
         <Filename Value="rtfp_constants.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="42" Y="15"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit55>
       <Unit56>
         <Filename Value="rtfp_format_component.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="503"/>
         <CursorPos X="48" Y="506"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit56>
       <Unit57>
         <Filename Value="rtfp_tags.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="46" Y="155"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit57>
       <Unit58>
         <Filename Value="rtfp_misc.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="20" Y="33"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit58>
       <Unit59>
         <Filename Value="rtfp_dialog.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="43" Y="40"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit59>
       <Unit60>
         <Filename Value="rtfp_type.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6"/>
         <CursorPos X="30" Y="28"/>
-        <UsageCount Value="176"/>
+        <UsageCount Value="175"/>
       </Unit60>
       <Unit61>
         <Filename Value="form_new_project.pas"/>
@@ -565,7 +572,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="91"/>
         <CursorPos X="54" Y="108"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit61>
       <Unit62>
         <Filename Value="form_cite_trans.pas"/>
@@ -575,7 +582,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="35"/>
         <CursorPos X="90" Y="39"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit62>
       <Unit63>
         <Filename Value="form_import.pas"/>
@@ -585,7 +592,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="264"/>
         <CursorPos X="96" Y="265"/>
-        <UsageCount Value="181"/>
+        <UsageCount Value="180"/>
       </Unit63>
       <Unit64>
         <Filename Value="form_classmanager.pas"/>
@@ -595,7 +602,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="81" Y="27"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit64>
       <Unit65>
         <Filename Value="form_appearance.pas"/>
@@ -604,7 +611,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="102" Y="3"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit65>
       <Unit66>
         <Filename Value="form_options.pas"/>
@@ -614,7 +621,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="41"/>
         <CursorPos X="42" Y="43"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit66>
       <Unit67>
         <Filename Value="form_report_tool.pas"/>
@@ -624,7 +631,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="20"/>
         <CursorPos X="74" Y="22"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit67>
       <Unit68>
         <Filename Value="form_repeated_checker.pas"/>
@@ -634,7 +641,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="291"/>
         <CursorPos X="46" Y="292"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit68>
       <Unit69>
         <Filename Value="form_project_profile.pas"/>
@@ -643,7 +650,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="55" Y="4"/>
-        <UsageCount Value="175"/>
+        <UsageCount Value="174"/>
       </Unit69>
       <Unit70>
         <Filename Value="form_field_display_option.pas"/>
@@ -653,7 +660,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="46"/>
         <CursorPos X="65" Y="49"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit70>
       <Unit71>
         <Filename Value="form_formatedit_option.pas"/>
@@ -663,7 +670,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="130"/>
         <CursorPos X="15" Y="121"/>
-        <UsageCount Value="177"/>
+        <UsageCount Value="176"/>
       </Unit71>
       <Unit72>
         <Filename Value="..\AufScript\aufscript_frame.pas"/>
@@ -683,7 +690,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="3540"/>
         <CursorPos Y="3558"/>
-        <UsageCount Value="179"/>
+        <UsageCount Value="178"/>
       </Unit73>
       <Unit74>
         <Filename Value="..\AufScript\auf_ram_var.pas"/>
@@ -691,13 +698,13 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="174"/>
+        <UsageCount Value="173"/>
       </Unit74>
       <Unit75>
         <Filename Value="..\FPC_Unit\Auf\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="160"/>
+        <UsageCount Value="159"/>
       </Unit75>
       <Unit76>
         <Filename Value="..\FPC_Unit\ACL\ListViewEx\acl_listview.pas"/>
@@ -705,14 +712,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="34"/>
         <CursorPos Y="66"/>
-        <UsageCount Value="59"/>
+        <UsageCount Value="58"/>
       </Unit76>
       <Unit77>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\systemh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1119"/>
         <CursorPos X="11" Y="1136"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit77>
       <Unit78>
         <Filename Value="D:\Lazarus\lcl\stdctrls.pp"/>
@@ -720,28 +727,28 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="483"/>
         <CursorPos X="3" Y="497"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit78>
       <Unit79>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="178"/>
         <CursorPos X="3" Y="197"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit79>
       <Unit80>
         <Filename Value="C:\lazarus\lcl\include\picture.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="560"/>
         <CursorPos X="11" Y="577"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit80>
       <Unit81>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="197"/>
         <CursorPos X="14" Y="217"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit81>
       <Unit82>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\bufdataset.pas"/>
@@ -749,14 +756,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="582"/>
         <CursorPos X="29" Y="612"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit82>
       <Unit83>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\ascdef.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="102"/>
         <CursorPos X="10" Y="122"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit83>
       <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win64\system.pp"/>
@@ -764,65 +771,65 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="121"/>
         <CursorPos Y="16"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit84>
       <Unit85>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\system.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="73"/>
         <CursorPos X="34" Y="10"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit85>
       <Unit86>
         <Filename Value="data_access.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="449"/>
         <CursorPos X="3" Y="32"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit86>
       <Unit87>
         <Filename Value="formatedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="141"/>
         <CursorPos X="68" Y="263"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit87>
       <Unit88>
         <Filename Value="papers.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="54" Y="4"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit88>
       <Unit89>
         <Filename Value="events.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21" Y="10"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit89>
       <Unit90>
         <Filename Value="tags.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="32" Y="10"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit90>
       <Unit91>
         <Filename Value="paper.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="5" Y="3"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit91>
       <Unit92>
         <Filename Value="cite_tool.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="667"/>
         <CursorPos X="40" Y="679"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit92>
       <Unit93>
         <Filename Value="forms\form_classmanager.lfm"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
       </Unit93>
       <Unit94>
@@ -830,7 +837,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="70"/>
         <CursorPos X="25" Y="73"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit94>
       <Unit95>
         <Filename Value="C:\lazarus\lcl\dbgrids.pas"/>
@@ -838,21 +845,21 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="535"/>
         <CursorPos X="25" Y="563"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit95>
       <Unit96>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\registry.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="79"/>
         <CursorPos X="25" Y="104"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit96>
       <Unit97>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\winreg.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="167"/>
         <CursorPos X="3" Y="172"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit97>
       <Unit98>
         <Filename Value="C:\lazarus\lcl\forms.pp"/>
@@ -860,21 +867,21 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="768"/>
         <CursorPos X="14" Y="784"/>
-        <UsageCount Value="2"/>
+        <UsageCount Value="1"/>
       </Unit98>
       <Unit99>
         <Filename Value="C:\lazarus\lcl\include\control.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2236"/>
         <CursorPos Y="2253"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit99>
       <Unit100>
         <Filename Value="C:\lazarus\lcl\include\wincontrol.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6808"/>
         <CursorPos Y="6825"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit100>
       <Unit101>
         <Filename Value="C:\lazarus\lcl\extctrls.pp"/>
@@ -882,7 +889,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="1035"/>
         <CursorPos X="17" Y="1053"/>
-        <UsageCount Value="1"/>
+        <UsageCount Value="0"/>
       </Unit101>
       <Unit102>
         <Filename Value="C:\lazarus\lcl\graphics.pp"/>
@@ -890,7 +897,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="679"/>
         <CursorPos X="3" Y="698"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit102>
       <Unit103>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\regexpr\src\regexpr.pas"/>
@@ -898,7 +905,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="416"/>
         <CursorPos X="33" Y="298"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit103>
       <Unit104>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-image\src\fpcanvas.pp"/>
@@ -906,35 +913,35 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="36" Y="158"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit104>
       <Unit105>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\memds\memds.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="127"/>
         <CursorPos X="74" Y="154"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit105>
       <Unit106>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysuni.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="267"/>
         <CursorPos X="5" Y="277"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit106>
       <Unit107>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\lists.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="773"/>
         <CursorPos Y="775"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit107>
       <Unit108>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\sqldb\sqldb.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="576"/>
         <CursorPos X="14" Y="593"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit108>
       <Unit109>
         <Filename Value="C:\lazarus\lcl\stdctrls.pp"/>
@@ -942,7 +949,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="704"/>
         <CursorPos X="30" Y="727"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit109>
       <Unit110>
         <Filename Value="C:\lazarus\lcl\controls.pp"/>
@@ -950,7 +957,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="206"/>
         <CursorPos X="3" Y="224"/>
-        <UsageCount Value="2"/>
+        <UsageCount Value="1"/>
       </Unit110>
       <Unit111>
         <Filename Value="C:\lazarus\lcl\lclclasses.pp"/>
@@ -958,7 +965,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="24"/>
         <CursorPos X="3" Y="42"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit111>
       <Unit112>
         <Filename Value="..\ACL_ListView\acl_listview.pas"/>
@@ -966,7 +973,7 @@
         <EditorIndex Value="1"/>
         <TopLine Value="20"/>
         <CursorPos X="17" Y="30"/>
-        <UsageCount Value="55"/>
+        <UsageCount Value="61"/>
         <Loaded Value="True"/>
       </Unit112>
       <Unit113>
@@ -975,27 +982,27 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="95"/>
         <CursorPos Y="112"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit113>
       <Unit114>
         <Filename Value="C:\lazarus\lcl\interfaces\win32\win32callback.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2652"/>
         <CursorPos Y="2671"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit114>
       <Unit115>
         <Filename Value="C:\lazarus\lcl\include\customlistview.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1350"/>
         <CursorPos Y="1385"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit115>
       <Unit116>
         <Filename Value="C:\lazarus\lcl\include\listitems.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos Y="27"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit116>
       <Unit117>
         <Filename Value="C:\lazarus\lcl\comctrls.pp"/>
@@ -1003,41 +1010,41 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="974"/>
         <CursorPos X="3" Y="992"/>
-        <UsageCount Value="2"/>
+        <UsageCount Value="1"/>
       </Unit117>
       <Unit118>
         <Filename Value="rtfp_core\rtfp_db_sorter.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="13"/>
-        <UsageCount Value="14"/>
+        <UsageCount Value="13"/>
       </Unit118>
       <Unit119>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysutilh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="302"/>
         <CursorPos X="13" Y="320"/>
-        <UsageCount Value="5"/>
+        <UsageCount Value="4"/>
       </Unit119>
       <Unit120>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysutils.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="154"/>
         <CursorPos X="9" Y="158"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit120>
       <Unit121>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\inc\objpash.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="176"/>
         <CursorPos X="23" Y="194"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit121>
       <Unit122>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\dataset.inc"/>
-        <EditorIndex Value="21"/>
+        <EditorIndex Value="22"/>
         <TopLine Value="2001"/>
         <CursorPos X="3" Y="2017"/>
-        <UsageCount Value="30"/>
+        <UsageCount Value="36"/>
         <Loaded Value="True"/>
       </Unit122>
       <Unit123>
@@ -1045,130 +1052,98 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="241"/>
         <CursorPos X="71" Y="244"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit123>
     </Units>
-    <JumpHistory Count="30" HistoryIndex="27">
+    <JumpHistory Count="22" HistoryIndex="21">
       <Position1>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="385" TopLine="366"/>
+        <Filename Value="forms\form_options.pas"/>
+        <Caret Line="244" Column="56" TopLine="223"/>
       </Position1>
       <Position2>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="387" TopLine="366"/>
+        <Filename Value="forms\form_options.pas"/>
+        <Caret Line="280" Column="72" TopLine="259"/>
       </Position2>
       <Position3>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="384" TopLine="366"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="381" Column="7" TopLine="364"/>
       </Position3>
       <Position4>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="391" TopLine="366"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="388" Column="28" TopLine="364"/>
       </Position4>
       <Position5>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="381" TopLine="366"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2407" Column="24" TopLine="2394"/>
       </Position5>
       <Position6>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="382" TopLine="366"/>
+        <Filename Value="rtfp_core\rtfp_type.pas"/>
+        <Caret Line="30" Column="11" TopLine="3"/>
       </Position6>
       <Position7>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="383" TopLine="366"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="384" Column="61" TopLine="366"/>
       </Position7>
       <Position8>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="384" TopLine="366"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2283" Column="24" TopLine="2271"/>
       </Position8>
       <Position9>
         <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="385" TopLine="366"/>
+        <Caret Line="493" Column="27" TopLine="486"/>
       </Position9>
       <Position10>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="386" TopLine="366"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="116" Column="21" TopLine="94"/>
       </Position10>
       <Position11>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="382" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="111" Column="12" TopLine="94"/>
       </Position11>
       <Position12>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="381" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="122" Column="116" TopLine="94"/>
       </Position12>
       <Position13>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="382" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="123" Column="116" TopLine="95"/>
       </Position13>
       <Position14>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="383" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="46" Column="37" TopLine="28"/>
       </Position14>
       <Position15>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="384" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="128" Column="7" TopLine="105"/>
       </Position15>
       <Position16>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="385" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="35" Column="15" TopLine="18"/>
       </Position16>
       <Position17>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="386" TopLine="363"/>
+        <Filename Value="forms\form_field_change.pas"/>
+        <Caret Line="129" Column="28" TopLine="111"/>
       </Position17>
       <Position18>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="1955" Column="3" TopLine="674"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2078" Column="35" TopLine="2062"/>
       </Position18>
       <Position19>
-        <Filename Value="rtfp_core\control_interface.inc"/>
-        <Caret Line="386" Column="15" TopLine="363"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2079" Column="41" TopLine="2061"/>
       </Position19>
       <Position20>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="419" Column="28" TopLine="399"/>
+        <Filename Value="rtfp_main.pas"/>
+        <Caret Line="2473" Column="3" TopLine="2483"/>
       </Position20>
       <Position21>
-        <Filename Value="forms\form_report_tool.pas"/>
-        <Caret Line="420" Column="11" TopLine="405"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="19" Column="14" TopLine="7"/>
       </Position21>
       <Position22>
-        <Filename Value="rtfp_core\access_field.inc"/>
-        <Caret Line="11" Column="34"/>
+        <Filename Value="rtfp_core\rtfp_class.pas"/>
+        <Caret Line="62" Column="23" TopLine="34"/>
       </Position22>
-      <Position23>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="207" TopLine="195"/>
-      </Position23>
-      <Position24>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="202" TopLine="195"/>
-      </Position24>
-      <Position25>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="203" TopLine="195"/>
-      </Position25>
-      <Position26>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="205" TopLine="195"/>
-      </Position26>
-      <Position27>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="206" Column="23" TopLine="191"/>
-      </Position27>
-      <Position28>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="207" Column="57" TopLine="191"/>
-      </Position28>
-      <Position29>
-        <Filename Value="RTFP_Desktop.lpr"/>
-        <Caret Line="20" TopLine="3"/>
-      </Position29>
-      <Position30>
-        <Filename Value="rtfp_core\rtfp_dataset_sorter.pas"/>
-        <Caret Line="170" Column="20" TopLine="143"/>
-      </Position30>
     </JumpHistory>
   </ProjectSession>
   <Debugging>

--- a/RTFP_Desktop.lps
+++ b/RTFP_Desktop.lps
@@ -8,11 +8,10 @@
       <Unit0>
         <Filename Value="RTFP_Desktop.lpr"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="18"/>
-        <TopLine Value="2"/>
-        <CursorPos Y="37"/>
+        <EditorIndex Value="-1"/>
+        <TopLine Value="3"/>
+        <CursorPos X="51" Y="22"/>
         <UsageCount Value="201"/>
-        <Loaded Value="True"/>
       </Unit0>
       <Unit1>
         <Filename Value="rtfp_main.pas"/>
@@ -21,8 +20,8 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="RTFP_main"/>
-        <TopLine Value="770"/>
-        <CursorPos X="45" Y="788"/>
+        <TopLine Value="133"/>
+        <CursorPos X="40" Y="20"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -33,7 +32,7 @@
         <ComponentName Value="Form_FileSource"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="34"/>
+        <EditorIndex Value="33"/>
         <TopLine Value="73"/>
         <CursorPos X="16" Y="87"/>
         <UsageCount Value="202"/>
@@ -43,7 +42,7 @@
       <Unit3>
         <Filename Value="sync\sync_timer.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="35"/>
+        <EditorIndex Value="34"/>
         <TopLine Value="7"/>
         <CursorPos X="16" Y="25"/>
         <UsageCount Value="200"/>
@@ -65,7 +64,7 @@
         <ComponentName Value="Form_CiteTrans"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="24"/>
+        <EditorIndex Value="23"/>
         <TopLine Value="136"/>
         <CursorPos X="13" Y="150"/>
         <UsageCount Value="201"/>
@@ -78,7 +77,7 @@
         <ComponentName Value="ClassManagerForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="33"/>
+        <EditorIndex Value="32"/>
         <TopLine Value="177"/>
         <CursorPos X="22" Y="192"/>
         <UsageCount Value="201"/>
@@ -136,7 +135,7 @@
         <ComponentName Value="FormOptions"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="28"/>
+        <EditorIndex Value="27"/>
         <TopLine Value="179"/>
         <CursorPos X="24" Y="191"/>
         <UsageCount Value="201"/>
@@ -167,7 +166,7 @@
         <ComponentName Value="FormReportTool"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="32"/>
+        <EditorIndex Value="31"/>
         <TopLine Value="432"/>
         <CursorPos X="33" Y="452"/>
         <UsageCount Value="201"/>
@@ -177,7 +176,7 @@
       <Unit15>
         <Filename Value="rtfp_core\rtfp_class.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="27"/>
+        <EditorIndex Value="26"/>
         <CursorPos X="22" Y="74"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -185,7 +184,7 @@
       <Unit16>
         <Filename Value="rtfp_core\rtfp_constants.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="30"/>
+        <EditorIndex Value="29"/>
         <TopLine Value="16"/>
         <CursorPos X="3" Y="52"/>
         <UsageCount Value="201"/>
@@ -196,17 +195,17 @@
         <IsPartOfProject Value="True"/>
         <UnitName Value="RTFP_definition"/>
         <EditorIndex Value="17"/>
-        <TopLine Value="306"/>
-        <CursorPos X="14" Y="324"/>
+        <TopLine Value="279"/>
+        <CursorPos X="3" Y="93"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit17>
       <Unit18>
         <Filename Value="rtfp_core\rtfp_dialog.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="36"/>
-        <TopLine Value="598"/>
-        <CursorPos X="18" Y="555"/>
+        <EditorIndex Value="35"/>
+        <TopLine Value="112"/>
+        <CursorPos X="5" Y="130"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit18>
@@ -214,15 +213,15 @@
         <Filename Value="rtfp_core\rtfp_field.pas"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="14"/>
-        <TopLine Value="414"/>
-        <CursorPos Y="415"/>
+        <TopLine Value="46"/>
+        <CursorPos X="57" Y="63"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit19>
       <Unit20>
         <Filename Value="rtfp_core\rtfp_files.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="23"/>
+        <EditorIndex Value="22"/>
         <TopLine Value="79"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -230,16 +229,16 @@
       <Unit21>
         <Filename Value="rtfp_core\rtfp_format_component.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="31"/>
-        <TopLine Value="176"/>
-        <CursorPos X="37" Y="128"/>
+        <EditorIndex Value="30"/>
+        <TopLine Value="34"/>
+        <CursorPos X="3" Y="46"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
       </Unit21>
       <Unit22>
         <Filename Value="rtfp_core\rtfp_misc.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="25"/>
+        <EditorIndex Value="24"/>
         <TopLine Value="67"/>
         <CursorPos Y="28"/>
         <UsageCount Value="201"/>
@@ -257,7 +256,7 @@
       <Unit24>
         <Filename Value="rtfp_core\rtfp_type.pas"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="26"/>
+        <EditorIndex Value="25"/>
         <CursorPos X="46" Y="13"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -286,7 +285,7 @@
         <IsVisibleTab Value="True"/>
         <EditorIndex Value="4"/>
         <TopLine Value="93"/>
-        <CursorPos X="64" Y="109"/>
+        <CursorPos X="22" Y="105"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit27>
@@ -296,7 +295,7 @@
         <EditorIndex Value="1"/>
         <TopLine Value="4"/>
         <CursorPos X="34" Y="21"/>
-        <UsageCount Value="194"/>
+        <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit28>
       <Unit29>
@@ -308,7 +307,7 @@
         <EditorIndex Value="11"/>
         <TopLine Value="94"/>
         <CursorPos X="3" Y="99"/>
-        <UsageCount Value="153"/>
+        <UsageCount Value="160"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit29>
@@ -318,43 +317,42 @@
         <EditorIndex Value="12"/>
         <TopLine Value="79"/>
         <CursorPos X="40" Y="55"/>
-        <UsageCount Value="141"/>
+        <UsageCount Value="148"/>
         <Loaded Value="True"/>
       </Unit30>
       <Unit31>
         <Filename Value="rtfp_core\formatedit_component.inc"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="3"/>
-        <TopLine Value="209"/>
-        <CursorPos X="34" Y="227"/>
-        <UsageCount Value="152"/>
+        <TopLine Value="91"/>
+        <CursorPos X="114" Y="101"/>
+        <UsageCount Value="159"/>
         <Loaded Value="True"/>
       </Unit31>
       <Unit32>
         <Filename Value="rtfp_core\access_field.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="21"/>
-        <TopLine Value="105"/>
-        <CursorPos X="3" Y="111"/>
-        <UsageCount Value="151"/>
+        <EditorIndex Value="20"/>
+        <CursorPos X="34" Y="11"/>
+        <UsageCount Value="158"/>
         <Loaded Value="True"/>
       </Unit32>
       <Unit33>
         <Filename Value="rtfp_core\control_interface.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="22"/>
+        <EditorIndex Value="21"/>
         <TopLine Value="322"/>
         <CursorPos X="62" Y="341"/>
-        <UsageCount Value="151"/>
+        <UsageCount Value="158"/>
         <Loaded Value="True"/>
       </Unit33>
       <Unit34>
         <Filename Value="rtfp_core\access_data.inc"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="5"/>
-        <TopLine Value="238"/>
-        <CursorPos X="46" Y="285"/>
-        <UsageCount Value="151"/>
+        <TopLine Value="216"/>
+        <CursorPos X="91" Y="224"/>
+        <UsageCount Value="158"/>
         <Loaded Value="True"/>
       </Unit34>
       <Unit35>
@@ -363,14 +361,15 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="393"/>
         <CursorPos X="39" Y="415"/>
-        <UsageCount Value="145"/>
+        <UsageCount Value="152"/>
       </Unit35>
       <Unit36>
         <Filename Value="rtfp_core\aufunc.inc"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="6"/>
-        <CursorPos X="30" Y="122"/>
-        <UsageCount Value="137"/>
+        <TopLine Value="423"/>
+        <CursorPos X="28" Y="439"/>
+        <UsageCount Value="144"/>
         <Loaded Value="True"/>
       </Unit36>
       <Unit37>
@@ -379,23 +378,23 @@
         <EditorIndex Value="9"/>
         <TopLine Value="256"/>
         <CursorPos X="27" Y="300"/>
-        <UsageCount Value="126"/>
+        <UsageCount Value="133"/>
         <Loaded Value="True"/>
       </Unit37>
       <Unit38>
         <Filename Value="rtfp_core\events.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="20"/>
-        <CursorPos Y="19"/>
-        <UsageCount Value="122"/>
+        <EditorIndex Value="19"/>
+        <CursorPos X="23" Y="20"/>
+        <UsageCount Value="129"/>
         <Loaded Value="True"/>
       </Unit38>
       <Unit39>
         <Filename Value="rtfp_core\access_attrs.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="29"/>
+        <EditorIndex Value="28"/>
         <CursorPos X="27" Y="16"/>
-        <UsageCount Value="110"/>
+        <UsageCount Value="117"/>
         <Loaded Value="True"/>
       </Unit39>
       <Unit40>
@@ -405,7 +404,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="110"/>
+        <UsageCount Value="117"/>
       </Unit40>
       <Unit41>
         <Filename Value="rtfp_core\image.inc"/>
@@ -414,7 +413,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="110"/>
+        <UsageCount Value="117"/>
       </Unit41>
       <Unit42>
         <Filename Value="rtfp_core\notes.inc"/>
@@ -423,15 +422,15 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="110"/>
+        <UsageCount Value="117"/>
       </Unit42>
       <Unit43>
         <Filename Value="rtfp_core\paper.inc"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="19"/>
+        <EditorIndex Value="18"/>
         <TopLine Value="458"/>
-        <CursorPos Y="465"/>
-        <UsageCount Value="110"/>
+        <CursorPos X="16" Y="464"/>
+        <UsageCount Value="117"/>
         <Loaded Value="True"/>
       </Unit43>
       <Unit44>
@@ -441,7 +440,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="110"/>
+        <UsageCount Value="117"/>
       </Unit44>
       <Unit45>
         <Filename Value="rtfp_core\update.inc"/>
@@ -450,7 +449,7 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="110"/>
+        <UsageCount Value="117"/>
       </Unit45>
       <Unit46>
         <Filename Value="..\FPC_Unit\Auf\aufscript_frame.pas"/>
@@ -459,27 +458,27 @@
         <ResourceBaseClass Value="Frame"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="82" Y="9"/>
-        <UsageCount Value="180"/>
+        <UsageCount Value="179"/>
       </Unit46>
       <Unit47>
         <Filename Value="..\FPC_Unit\Auf\synhighlighterauf.pas"/>
         <UnitName Value="SynHighlighterAuf"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="15"/>
+        <UsageCount Value="14"/>
       </Unit47>
       <Unit48>
         <Filename Value="rtfp_pdfium.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="164"/>
         <CursorPos X="60" Y="191"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit48>
       <Unit49>
         <Filename Value="rtfp_pdfobj.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="217"/>
         <CursorPos X="73" Y="217"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit49>
       <Unit50>
         <Filename Value="rtfp_definition.pas"/>
@@ -487,69 +486,69 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="230"/>
         <CursorPos X="14" Y="242"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit50>
       <Unit51>
         <Filename Value="rtfp_field.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="76"/>
         <CursorPos X="15" Y="90"/>
-        <UsageCount Value="190"/>
+        <UsageCount Value="189"/>
       </Unit51>
       <Unit52>
         <Filename Value="rtfp_class.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="3"/>
         <CursorPos X="15" Y="17"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit52>
       <Unit53>
         <Filename Value="rtfp_files.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="74"/>
         <CursorPos X="45" Y="77"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit53>
       <Unit54>
         <Filename Value="rtfp_constants.pas"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="42" Y="15"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit54>
       <Unit55>
         <Filename Value="rtfp_format_component.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="503"/>
         <CursorPos X="48" Y="506"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit55>
       <Unit56>
         <Filename Value="rtfp_tags.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="46" Y="155"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit56>
       <Unit57>
         <Filename Value="rtfp_misc.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="20" Y="33"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit57>
       <Unit58>
         <Filename Value="rtfp_dialog.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="43" Y="40"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit58>
       <Unit59>
         <Filename Value="rtfp_type.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="6"/>
         <CursorPos X="30" Y="28"/>
-        <UsageCount Value="186"/>
+        <UsageCount Value="185"/>
       </Unit59>
       <Unit60>
         <Filename Value="form_new_project.pas"/>
@@ -559,7 +558,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="91"/>
         <CursorPos X="54" Y="108"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit60>
       <Unit61>
         <Filename Value="form_cite_trans.pas"/>
@@ -569,7 +568,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="35"/>
         <CursorPos X="90" Y="39"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit61>
       <Unit62>
         <Filename Value="form_import.pas"/>
@@ -579,7 +578,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="264"/>
         <CursorPos X="96" Y="265"/>
-        <UsageCount Value="191"/>
+        <UsageCount Value="190"/>
       </Unit62>
       <Unit63>
         <Filename Value="form_classmanager.pas"/>
@@ -589,7 +588,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="26"/>
         <CursorPos X="81" Y="27"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit63>
       <Unit64>
         <Filename Value="form_appearance.pas"/>
@@ -598,7 +597,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="102" Y="3"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit64>
       <Unit65>
         <Filename Value="form_options.pas"/>
@@ -608,7 +607,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="41"/>
         <CursorPos X="42" Y="43"/>
-        <UsageCount Value="187"/>
+        <UsageCount Value="186"/>
       </Unit65>
       <Unit66>
         <Filename Value="form_report_tool.pas"/>
@@ -618,7 +617,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="20"/>
         <CursorPos X="74" Y="22"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit66>
       <Unit67>
         <Filename Value="form_repeated_checker.pas"/>
@@ -628,7 +627,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="291"/>
         <CursorPos X="46" Y="292"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit67>
       <Unit68>
         <Filename Value="form_project_profile.pas"/>
@@ -637,7 +636,7 @@
         <ResourceBaseClass Value="Form"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="55" Y="4"/>
-        <UsageCount Value="185"/>
+        <UsageCount Value="184"/>
       </Unit68>
       <Unit69>
         <Filename Value="form_field_display_option.pas"/>
@@ -647,7 +646,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="46"/>
         <CursorPos X="65" Y="49"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit69>
       <Unit70>
         <Filename Value="form_formatedit_option.pas"/>
@@ -657,7 +656,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="130"/>
         <CursorPos X="15" Y="121"/>
-        <UsageCount Value="187"/>
+        <UsageCount Value="186"/>
       </Unit70>
       <Unit71>
         <Filename Value="..\AufScript\aufscript_frame.pas"/>
@@ -685,13 +684,13 @@
         <WindowIndex Value="-1"/>
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
-        <UsageCount Value="184"/>
+        <UsageCount Value="183"/>
       </Unit73>
       <Unit74>
         <Filename Value="..\FPC_Unit\Auf\apiglio_useful.pas"/>
         <UnitName Value="Apiglio_Useful"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="170"/>
+        <UsageCount Value="169"/>
       </Unit74>
       <Unit75>
         <Filename Value="..\FPC_Unit\ACL\ListViewEx\acl_listview.pas"/>
@@ -699,14 +698,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="34"/>
         <CursorPos Y="66"/>
-        <UsageCount Value="69"/>
+        <UsageCount Value="68"/>
       </Unit75>
       <Unit76>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\systemh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1119"/>
         <CursorPos X="11" Y="1136"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit76>
       <Unit77>
         <Filename Value="D:\Lazarus\lcl\stdctrls.pp"/>
@@ -714,28 +713,28 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="483"/>
         <CursorPos X="3" Y="497"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit77>
       <Unit78>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
-        <TopLine Value="1752"/>
-        <CursorPos X="3" Y="1770"/>
-        <UsageCount Value="9"/>
+        <TopLine Value="479"/>
+        <CursorPos X="17" Y="497"/>
+        <UsageCount Value="10"/>
       </Unit78>
       <Unit79>
         <Filename Value="C:\lazarus\lcl\include\picture.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="560"/>
         <CursorPos X="11" Y="577"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit79>
       <Unit80>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\db.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1924"/>
         <CursorPos X="3" Y="1942"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit80>
       <Unit81>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\bufdataset.pas"/>
@@ -743,21 +742,21 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="582"/>
         <CursorPos X="29" Y="612"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit81>
       <Unit82>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\objpas\classes\classesh.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="485"/>
         <CursorPos X="17" Y="497"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit82>
       <Unit83>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win\wininc\ascdef.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="102"/>
         <CursorPos X="10" Y="122"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit83>
       <Unit84>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\win64\system.pp"/>
@@ -765,65 +764,65 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="121"/>
         <CursorPos Y="16"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit84>
       <Unit85>
         <Filename Value="D:\Lazarus\fpc\3.0.4\source\rtl\inc\system.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="73"/>
         <CursorPos X="34" Y="10"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit85>
       <Unit86>
         <Filename Value="data_access.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="449"/>
         <CursorPos X="3" Y="32"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit86>
       <Unit87>
         <Filename Value="formatedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="141"/>
         <CursorPos X="68" Y="263"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit87>
       <Unit88>
         <Filename Value="papers.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="54" Y="4"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit88>
       <Unit89>
         <Filename Value="events.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21" Y="10"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit89>
       <Unit90>
         <Filename Value="tags.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="37"/>
         <CursorPos X="32" Y="10"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit90>
       <Unit91>
         <Filename Value="paper.inc"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="5" Y="3"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit91>
       <Unit92>
         <Filename Value="cite_tool.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="667"/>
         <CursorPos X="40" Y="679"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit92>
       <Unit93>
         <Filename Value="forms\form_classmanager.lfm"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
       </Unit93>
       <Unit94>
@@ -831,7 +830,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="70"/>
         <CursorPos X="25" Y="73"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit94>
       <Unit95>
         <Filename Value="C:\lazarus\lcl\dbgrids.pas"/>
@@ -839,49 +838,49 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="535"/>
         <CursorPos X="25" Y="563"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="3"/>
       </Unit95>
       <Unit96>
         <Filename Value="C:\lazarus\lcl\include\customedit.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="81"/>
         <CursorPos Y="100"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit96>
       <Unit97>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\fields.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="38"/>
         <CursorPos Y="42"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit97>
       <Unit98>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\registry.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="79"/>
         <CursorPos X="25" Y="104"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit98>
       <Unit99>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-registry\src\winreg.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="167"/>
         <CursorPos X="3" Y="172"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit99>
       <Unit100>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\win\wininc\func.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="931"/>
         <CursorPos X="10" Y="949"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit100>
       <Unit101>
         <Filename Value="C:\lazarus\lcl\include\customform.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2935"/>
         <CursorPos Y="2962"/>
-        <UsageCount Value="3"/>
+        <UsageCount Value="2"/>
       </Unit101>
       <Unit102>
         <Filename Value="C:\lazarus\lcl\forms.pp"/>
@@ -889,28 +888,28 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="602"/>
         <CursorPos X="3" Y="739"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit102>
       <Unit103>
         <Filename Value="C:\lazarus\lcl\include\control.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2236"/>
         <CursorPos Y="2253"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit103>
       <Unit104>
         <Filename Value="C:\lazarus\lcl\include\wincontrol.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="5381"/>
         <CursorPos Y="5398"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit104>
       <Unit105>
         <Filename Value="C:\lazarus\lcl\include\fpimagebitmap.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="123"/>
         <CursorPos Y="141"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="9"/>
       </Unit105>
       <Unit106>
         <Filename Value="C:\lazarus\lcl\extctrls.pp"/>
@@ -918,7 +917,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="1035"/>
         <CursorPos X="17" Y="1053"/>
-        <UsageCount Value="4"/>
+        <UsageCount Value="10"/>
       </Unit106>
       <Unit107>
         <Filename Value="C:\lazarus\lcl\graphics.pp"/>
@@ -926,7 +925,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="679"/>
         <CursorPos X="3" Y="698"/>
-        <UsageCount Value="14"/>
+        <UsageCount Value="13"/>
       </Unit107>
       <Unit108>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\regexpr\src\regexpr.pas"/>
@@ -934,14 +933,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="416"/>
         <CursorPos X="33" Y="298"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit108>
       <Unit109>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysunih.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="19"/>
         <CursorPos X="10" Y="48"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit109>
       <Unit110>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-image\src\fpcanvas.pp"/>
@@ -949,42 +948,42 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="140"/>
         <CursorPos X="36" Y="158"/>
-        <UsageCount Value="6"/>
+        <UsageCount Value="5"/>
       </Unit110>
       <Unit111>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\memds\memds.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="127"/>
         <CursorPos X="74" Y="154"/>
-        <UsageCount Value="8"/>
+        <UsageCount Value="7"/>
       </Unit111>
       <Unit112>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\sysutils\sysuni.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="267"/>
         <CursorPos X="5" Y="277"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit112>
       <Unit113>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\rtl\objpas\classes\lists.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="297"/>
         <CursorPos Y="306"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit113>
       <Unit114>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\sqldb\sqldb.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="576"/>
         <CursorPos X="14" Y="593"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit114>
       <Unit115>
         <Filename Value="C:\lazarus\fpc\3.0.4\source\packages\fcl-db\src\base\database.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="21"/>
         <CursorPos Y="21"/>
-        <UsageCount Value="10"/>
+        <UsageCount Value="9"/>
       </Unit115>
       <Unit116>
         <Filename Value="C:\lazarus\lcl\stdctrls.pp"/>
@@ -992,7 +991,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="704"/>
         <CursorPos X="30" Y="727"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit116>
       <Unit117>
         <Filename Value="C:\lazarus\lcl\controls.pp"/>
@@ -1000,7 +999,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="1914"/>
         <CursorPos X="36" Y="1936"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit117>
       <Unit118>
         <Filename Value="C:\lazarus\lcl\lclclasses.pp"/>
@@ -1008,14 +1007,14 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="24"/>
         <CursorPos X="3" Y="42"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit118>
       <Unit119>
         <Filename Value="..\ACL_ListView\acl_listview.pas"/>
         <UnitName Value="ACL_ListView"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="13"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit119>
       <Unit120>
         <Filename Value="C:\lazarus\lcl\lclmessageglue.pas"/>
@@ -1023,136 +1022,136 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="95"/>
         <CursorPos Y="112"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit120>
       <Unit121>
         <Filename Value="C:\lazarus\lcl\interfaces\win32\win32callback.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="2652"/>
         <CursorPos Y="2671"/>
-        <UsageCount Value="9"/>
+        <UsageCount Value="8"/>
       </Unit121>
     </Units>
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="211" TopLine="196"/>
+        <Filename Value="rtfp_core\aufunc.inc"/>
+        <Caret Line="496" TopLine="467"/>
       </Position1>
       <Position2>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="213" TopLine="196"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="209" TopLine="192"/>
       </Position2>
       <Position3>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="198" TopLine="191"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="171" TopLine="159"/>
       </Position3>
       <Position4>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="195" TopLine="188"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="564" Column="43" TopLine="541"/>
       </Position4>
       <Position5>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="190" TopLine="182"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="717" Column="15" TopLine="694"/>
       </Position5>
       <Position6>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="220" TopLine="196"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="152" Column="15" TopLine="135"/>
       </Position6>
       <Position7>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="771" TopLine="760"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="472" Column="17" TopLine="446"/>
       </Position7>
       <Position8>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="773" TopLine="760"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="144" Column="14" TopLine="126"/>
       </Position8>
       <Position9>
-        <Filename Value="rtfp_core\access_base.inc"/>
-        <Caret Line="271" TopLine="261"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="171" TopLine="153"/>
       </Position9>
       <Position10>
-        <Filename Value="rtfp_core\access_base.inc"/>
-        <Caret Line="272" TopLine="273"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="346" Column="15" TopLine="325"/>
       </Position10>
       <Position11>
-        <Filename Value="rtfp_core\access_base.inc"/>
-        <Caret Line="273" TopLine="255"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="472" Column="16" TopLine="442"/>
       </Position11>
       <Position12>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="773" TopLine="760"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="144" Column="14" TopLine="126"/>
       </Position12>
       <Position13>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="704" Column="29" TopLine="688"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="407" Column="3" TopLine="396"/>
       </Position13>
       <Position14>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="143" Column="15" TopLine="126"/>
+        <Caret Line="211" Column="20" TopLine="192"/>
       </Position14>
       <Position15>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="415" Column="70" TopLine="411"/>
+        <Caret Line="45" Column="60" TopLine="33"/>
       </Position15>
       <Position16>
         <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="135" Column="14" TopLine="117"/>
+        <Caret Line="276" Column="83" TopLine="250"/>
       </Position16>
       <Position17>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="53" Column="17" TopLine="33"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="1936" Column="22" TopLine="1909"/>
       </Position17>
       <Position18>
         <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="770" Column="21" TopLine="757"/>
+        <Caret Line="1922" Column="35" TopLine="1909"/>
       </Position18>
       <Position19>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="372" Column="30" TopLine="363"/>
+        <Filename Value="rtfp_core\rtfp_definition.pas"/>
+        <Caret Line="1108" Column="27" TopLine="1086"/>
       </Position19>
       <Position20>
-        <Filename Value="rtfp_core\rtfp_class.pas"/>
-        <Caret Line="62" Column="25" TopLine="45"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="221" Column="28" TopLine="209"/>
       </Position20>
       <Position21>
-        <Filename Value="rtfp_core\rtfp_field.pas"/>
-        <Caret Line="143" Column="24" TopLine="122"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="24" TopLine="34"/>
       </Position21>
       <Position22>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="776" Column="21" TopLine="760"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="71" Column="59" TopLine="65"/>
       </Position22>
       <Position23>
-        <Filename Value="rtfp_core\formatedit_list.inc"/>
-        <Caret Line="162" TopLine="55"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="89" Column="7" TopLine="65"/>
       </Position23>
       <Position24>
-        <Filename Value="rtfp_core\formatedit_list.inc"/>
-        <Caret Line="109" Column="43" TopLine="85"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="91" Column="19" TopLine="37"/>
       </Position24>
       <Position25>
-        <Filename Value="rtfp_core\formatedit_list.inc"/>
-        <Caret Line="93" TopLine="13"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="111" Column="26" TopLine="84"/>
       </Position25>
       <Position26>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="324" Column="38" TopLine="306"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="101" Column="103" TopLine="84"/>
       </Position26>
       <Position27>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="1168" Column="17" TopLine="1207"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="103" Column="17" TopLine="84"/>
       </Position27>
       <Position28>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="330" Column="15" TopLine="313"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="101" Column="36" TopLine="85"/>
       </Position28>
       <Position29>
-        <Filename Value="rtfp_core\formatedit_list.inc"/>
-        <Caret Line="194" Column="35" TopLine="172"/>
+        <Filename Value="rtfp_core\rtfp_field.pas"/>
+        <Caret Line="63" Column="57" TopLine="46"/>
       </Position29>
       <Position30>
-        <Filename Value="rtfp_core\rtfp_definition.pas"/>
-        <Caret Line="324" Column="14" TopLine="306"/>
+        <Filename Value="rtfp_core\formatedit_component.inc"/>
+        <Caret Line="101" Column="114" TopLine="91"/>
       </Position30>
     </JumpHistory>
   </ProjectSession>
@@ -1187,13 +1186,16 @@
         <Line Value="109"/>
       </Item4>
     </BreakPoints>
-    <Watches Count="2">
+    <Watches Count="3">
       <Item1>
         <Expression Value="regg"/>
       </Item1>
       <Item2>
         <Expression Value="dbf_name_no_ext"/>
       </Item2>
+      <Item3>
+        <Expression Value="Self"/>
+      </Item3>
     </Watches>
   </Debugging>
 </CONFIG>

--- a/forms/form_field_change.lfm
+++ b/forms/form_field_change.lfm
@@ -1,119 +1,16 @@
 object Form_FieldChange: TForm_FieldChange
-  Left = 1056
-  Height = 282
-  Top = 577
-  Width = 360
+  Left = 1097
+  Height = 495
+  Top = 456
+  Width = 402
   Caption = '字段属性'
-  ClientHeight = 282
-  ClientWidth = 360
+  ClientHeight = 495
+  ClientWidth = 402
   Constraints.MaxWidth = 640
   Constraints.MinWidth = 320
   DesignTimePPI = 144
   Position = poMainFormCenter
   LCLVersion = '1.8.4.0'
-  object Edit_FieldName: TEdit
-    AnchorSideLeft.Control = Label_FieldName
-    AnchorSideLeft.Side = asrBottom
-    AnchorSideTop.Control = Label_FieldName
-    AnchorSideTop.Side = asrCenter
-    AnchorSideRight.Control = Owner
-    AnchorSideRight.Side = asrBottom
-    Left = 120
-    Height = 32
-    Top = 16
-    Width = 220
-    Anchors = [akTop, akLeft, akRight]
-    BorderSpacing.Left = 10
-    BorderSpacing.Right = 20
-    TabOrder = 0
-    Text = 'Edit_FieldName'
-  end
-  object Label_FieldName: TLabel
-    AnchorSideLeft.Control = Owner
-    AnchorSideTop.Control = Owner
-    Left = 20
-    Height = 24
-    Top = 20
-    Width = 90
-    BorderSpacing.Left = 20
-    BorderSpacing.Top = 20
-    Caption = '字段名称：'
-    ParentColor = False
-  end
-  object Label_FieldType: TLabel
-    AnchorSideLeft.Control = Owner
-    AnchorSideTop.Control = Label_FieldName
-    AnchorSideTop.Side = asrBottom
-    Left = 20
-    Height = 24
-    Top = 64
-    Width = 90
-    BorderSpacing.Left = 20
-    BorderSpacing.Top = 20
-    Caption = '字段类型：'
-    ParentColor = False
-  end
-  object Label_FieldSize: TLabel
-    AnchorSideLeft.Control = Owner
-    AnchorSideTop.Control = Label_FieldType
-    AnchorSideTop.Side = asrBottom
-    Left = 20
-    Height = 24
-    Top = 108
-    Width = 90
-    BorderSpacing.Left = 20
-    BorderSpacing.Top = 20
-    Caption = '字段长度：'
-    ParentColor = False
-  end
-  object Edit_FieldSize: TEdit
-    AnchorSideLeft.Control = Label_FieldSize
-    AnchorSideLeft.Side = asrBottom
-    AnchorSideTop.Control = Label_FieldSize
-    AnchorSideTop.Side = asrCenter
-    AnchorSideRight.Control = Owner
-    AnchorSideRight.Side = asrBottom
-    Left = 120
-    Height = 32
-    Top = 104
-    Width = 220
-    Anchors = [akTop, akLeft, akRight]
-    BorderSpacing.Left = 10
-    BorderSpacing.Right = 20
-    TabOrder = 1
-    Text = 'Edit_FieldSize'
-  end
-  object ComboBox_FieldType: TComboBox
-    AnchorSideLeft.Control = Label_FieldType
-    AnchorSideLeft.Side = asrBottom
-    AnchorSideTop.Control = Label_FieldType
-    AnchorSideTop.Side = asrCenter
-    AnchorSideRight.Control = Owner
-    AnchorSideRight.Side = asrBottom
-    Left = 120
-    Height = 32
-    Top = 60
-    Width = 220
-    Anchors = [akTop, akLeft, akRight]
-    BorderSpacing.Left = 10
-    BorderSpacing.Right = 20
-    ItemHeight = 24
-    Items.Strings = (
-      '段落 Memo'
-      '字符串 String'
-      '布尔 Boolean'
-      '短整型 SmallInt'
-      '长整型 LargeInt'
-      '浮点型 Float'
-      '时间 DateTime'
-      '日期 Date'
-      '图像 Blob'
-      '系统自增 AutoInc'
-    )
-    OnChange = ComboBox_FieldTypeChange
-    Style = csDropDownList
-    TabOrder = 2
-  end
   object Button_ChangeField: TButton
     AnchorSideLeft.Control = Owner
     AnchorSideLeft.Side = asrCenter
@@ -123,42 +20,199 @@ object Form_FieldChange: TForm_FieldChange
     AnchorSideRight.Side = asrBottom
     AnchorSideBottom.Control = Owner
     AnchorSideBottom.Side = asrBottom
-    Left = 114
+    Left = 135
     Height = 32
-    Top = 240
+    Top = 455
     Width = 132
-    BorderSpacing.Left = 20
+    Anchors = [akLeft, akBottom]
     BorderSpacing.Top = 10
     BorderSpacing.Right = 20
-    BorderSpacing.Bottom = 10
+    BorderSpacing.Bottom = 8
     Caption = '应用修改'
     OnClick = Button_ChangeFieldClick
-    TabOrder = 3
-  end
-  object Memo_TypeChangeTip: TMemo
-    AnchorSideLeft.Control = Owner
-    AnchorSideTop.Control = Label_FieldSize
-    AnchorSideTop.Side = asrBottom
-    AnchorSideRight.Control = Owner
-    AnchorSideRight.Side = asrBottom
-    Left = 20
-    Height = 78
-    Top = 152
-    Width = 320
-    Anchors = [akTop, akLeft, akRight]
-    BorderSpacing.Left = 20
-    BorderSpacing.Top = 20
-    BorderSpacing.Right = 20
-    Enabled = False
-    ParentColor = True
-    TabOrder = 4
+    TabOrder = 0
   end
   object Button_information: TButton
-    Left = 296
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = Owner
+    AnchorSideBottom.Side = asrBottom
+    Left = 357
     Height = 32
-    Top = 240
+    Top = 455
     Width = 37
+    Anchors = [akRight, akBottom]
+    BorderSpacing.Right = 8
+    BorderSpacing.Bottom = 8
     Caption = '?'
-    TabOrder = 5
+    TabOrder = 1
+  end
+  object ScrollBox_FieldOption: TScrollBox
+    AnchorSideLeft.Control = Owner
+    AnchorSideTop.Control = Owner
+    AnchorSideRight.Control = Owner
+    AnchorSideRight.Side = asrBottom
+    AnchorSideBottom.Control = Button_ChangeField
+    Left = 0
+    Height = 445
+    Top = 0
+    Width = 402
+    HorzScrollBar.Page = 214
+    VertScrollBar.Page = 416
+    Anchors = [akTop, akLeft, akRight, akBottom]
+    ClientHeight = 441
+    ClientWidth = 398
+    TabOrder = 2
+    object Memo_TypeChangeTip: TMemo
+      AnchorSideLeft.Control = ScrollBox_FieldOption
+      AnchorSideTop.Control = Memo_ComboItem
+      AnchorSideTop.Side = asrBottom
+      AnchorSideRight.Control = ScrollBox_FieldOption
+      AnchorSideRight.Side = asrBottom
+      Left = 8
+      Height = 96
+      Top = 320
+      Width = 382
+      Anchors = [akTop, akLeft, akRight]
+      BorderSpacing.Left = 8
+      BorderSpacing.Top = 16
+      BorderSpacing.Right = 8
+      Enabled = False
+      ParentColor = True
+      TabOrder = 0
+    end
+    object Memo_ComboItem: TMemo
+      AnchorSideLeft.Control = ScrollBox_FieldOption
+      AnchorSideTop.Control = Label_FieldComboItem
+      AnchorSideTop.Side = asrBottom
+      AnchorSideRight.Control = ScrollBox_FieldOption
+      AnchorSideRight.Side = asrBottom
+      Left = 8
+      Height = 136
+      Top = 168
+      Width = 382
+      Anchors = [akTop, akLeft, akRight]
+      BorderSpacing.Left = 8
+      BorderSpacing.Top = 16
+      BorderSpacing.Right = 8
+      ScrollBars = ssVertical
+      TabOrder = 1
+    end
+    object Label_FieldComboItem: TLabel
+      AnchorSideLeft.Control = ScrollBox_FieldOption
+      AnchorSideTop.Control = Label_FieldSize
+      AnchorSideTop.Side = asrBottom
+      Left = 8
+      Height = 24
+      Top = 128
+      Width = 90
+      BorderSpacing.Left = 8
+      BorderSpacing.Top = 16
+      Caption = '字段选项：'
+      ParentColor = False
+    end
+    object Edit_FieldSize: TEdit
+      AnchorSideLeft.Control = Label_FieldType
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideTop.Control = Label_FieldSize
+      AnchorSideTop.Side = asrCenter
+      AnchorSideRight.Control = ScrollBox_FieldOption
+      AnchorSideRight.Side = asrBottom
+      Left = 106
+      Height = 32
+      Top = 84
+      Width = 284
+      Anchors = [akTop, akLeft, akRight]
+      BorderSpacing.Left = 8
+      BorderSpacing.Right = 8
+      TabOrder = 2
+      Text = 'Edit_FieldSize'
+    end
+    object ComboBox_FieldType: TComboBox
+      AnchorSideLeft.Control = Label_FieldType
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideTop.Control = Label_FieldType
+      AnchorSideTop.Side = asrCenter
+      AnchorSideRight.Control = ScrollBox_FieldOption
+      AnchorSideRight.Side = asrBottom
+      Left = 106
+      Height = 32
+      Top = 44
+      Width = 284
+      Anchors = [akTop, akLeft, akRight]
+      BorderSpacing.Left = 8
+      BorderSpacing.Right = 8
+      ItemHeight = 24
+      Items.Strings = (
+        '段落 Memo'
+        '字符串 String'
+        '布尔 Boolean'
+        '短整型 SmallInt'
+        '长整型 LargeInt'
+        '浮点型 Float'
+        '时间 DateTime'
+        '日期 Date'
+        '图像 Blob'
+        '系统自增 AutoInc'
+      )
+      OnChange = ComboBox_FieldTypeChange
+      Style = csDropDownList
+      TabOrder = 3
+    end
+    object Edit_FieldName: TEdit
+      AnchorSideLeft.Control = Label_FieldName
+      AnchorSideLeft.Side = asrBottom
+      AnchorSideTop.Control = Label_FieldName
+      AnchorSideTop.Side = asrCenter
+      AnchorSideRight.Control = ScrollBox_FieldOption
+      AnchorSideRight.Side = asrBottom
+      Left = 106
+      Height = 32
+      Top = 4
+      Width = 284
+      Anchors = [akTop, akLeft, akRight]
+      BorderSpacing.Left = 8
+      BorderSpacing.Right = 8
+      TabOrder = 4
+      Text = 'Edit_FieldName'
+    end
+    object Label_FieldSize: TLabel
+      AnchorSideLeft.Control = ScrollBox_FieldOption
+      AnchorSideTop.Control = Label_FieldType
+      AnchorSideTop.Side = asrBottom
+      Left = 8
+      Height = 24
+      Top = 88
+      Width = 90
+      BorderSpacing.Left = 8
+      BorderSpacing.Top = 16
+      Caption = '字段长度：'
+      ParentColor = False
+    end
+    object Label_FieldType: TLabel
+      AnchorSideLeft.Control = ScrollBox_FieldOption
+      AnchorSideTop.Control = Label_FieldName
+      AnchorSideTop.Side = asrBottom
+      Left = 8
+      Height = 24
+      Top = 48
+      Width = 90
+      BorderSpacing.Left = 8
+      BorderSpacing.Top = 16
+      Caption = '字段类型：'
+      ParentColor = False
+    end
+    object Label_FieldName: TLabel
+      AnchorSideLeft.Control = ScrollBox_FieldOption
+      AnchorSideTop.Control = ScrollBox_FieldOption
+      Left = 8
+      Height = 24
+      Top = 8
+      Width = 90
+      BorderSpacing.Left = 8
+      BorderSpacing.Top = 8
+      Caption = '字段名称：'
+      ParentColor = False
+    end
   end
 end

--- a/forms/form_field_change.pas
+++ b/forms/form_field_change.pas
@@ -18,10 +18,13 @@ type
     Edit_FieldName: TEdit;
     Edit_FieldSize: TEdit;
     ComboBox_FieldType: TComboBox;
+    Label_FieldComboItem: TLabel;
     Label_FieldName: TLabel;
     Label_FieldType: TLabel;
     Label_FieldSize: TLabel;
+    Memo_ComboItem: TMemo;
     Memo_TypeChangeTip: TMemo;
+    ScrollBox_FieldOption: TScrollBox;
     procedure Button_ChangeFieldClick(Sender: TObject);
     procedure ComboBox_FieldTypeChange(Sender: TObject);
   private
@@ -116,6 +119,8 @@ begin
   //再改名
   if CurrentField.FieldDef.Name<>new_name then CurrentRTFP.RenameField(CurrentField.FieldName,new_name,CurrentField.AttrsGroup.Name);
   ModalResult:=mrOK;
+  //最后改combo选项
+  CurrentField.ComboItem.Assign(Memo_ComboItem.Lines);
 end;
 
 procedure TForm_FieldChange.Call(AAttrsField:TAttrsField);
@@ -136,7 +141,7 @@ begin
     ftString:Edit_FieldSize.Enabled:=true;
     else Edit_FieldSize.Enabled:=false;
   end;
-
+  Memo_ComboItem.Lines.Assign(CurrentField.ComboItem);
 end;
 
 end.

--- a/forms/form_options.lfm
+++ b/forms/form_options.lfm
@@ -2,10 +2,10 @@ object FormOptions: TFormOptions
   Left = 1321
   Height = 557
   Top = 390
-  Width = 481
+  Width = 472
   Caption = '选项'
   ClientHeight = 557
-  ClientWidth = 481
+  ClientWidth = 472
   Constraints.MinHeight = 240
   Constraints.MinWidth = 400
   DesignTimePPI = 144
@@ -24,18 +24,59 @@ object FormOptions: TFormOptions
     Left = 0
     Height = 557
     Top = 0
-    Width = 481
-    ActivePage = TabSheet_Backup
+    Width = 472
+    ActivePage = TabSheet_MaingridShortcut
     Anchors = [akTop, akLeft, akRight, akBottom]
-    TabIndex = 3
+    TabIndex = 0
     TabOrder = 0
-    object TabSheet_Summary: TTabSheet
-      Caption = '总控制面板'
+    object TabSheet_MaingridShortcut: TTabSheet
+      Caption = '主表快捷键'
+      ClientHeight = 520
+      ClientWidth = 464
+      object RadioGroup_MGSC_CR: TRadioGroup
+        AnchorSideLeft.Control = TabSheet_MaingridShortcut
+        AnchorSideTop.Control = TabSheet_MaingridShortcut
+        AnchorSideRight.Control = TabSheet_MaingridShortcut
+        AnchorSideRight.Side = asrBottom
+        Left = 10
+        Height = 118
+        Top = 10
+        Width = 444
+        Anchors = [akTop, akLeft, akRight]
+        AutoFill = True
+        BorderSpacing.Left = 10
+        BorderSpacing.Top = 10
+        BorderSpacing.Right = 10
+        Caption = 'Ctrl+R 行为'
+        ChildSizing.LeftRightSpacing = 6
+        ChildSizing.EnlargeHorizontal = crsHomogenousChildResize
+        ChildSizing.EnlargeVertical = crsHomogenousChildResize
+        ChildSizing.ShrinkHorizontal = crsScaleChilds
+        ChildSizing.ShrinkVertical = crsScaleChilds
+        ChildSizing.Layout = cclLeftToRightThenTopToBottom
+        ChildSizing.ControlsPerLine = 3
+        ClientHeight = 89
+        ClientWidth = 440
+        Columns = 3
+        ItemIndex = 3
+        Items.Strings = (
+          '标题'
+          '路径'
+          '链接'
+          'GB/T 7714'
+          'APA'
+          'MLA'
+          '顺序编码制'
+          '著者-出版年制'
+        )
+        OnClick = RadioGroup_MGSC_CRClick
+        TabOrder = 0
+      end
     end
     object TabSheet_Sync: TTabSheet
       Caption = '文件同步'
       ClientHeight = 520
-      ClientWidth = 473
+      ClientWidth = 464
       object ScrollBox_Sync: TScrollBox
         AnchorSideLeft.Control = TabSheet_Sync
         AnchorSideTop.Control = TabSheet_Sync
@@ -46,12 +87,12 @@ object FormOptions: TFormOptions
         Left = 0
         Height = 520
         Top = 0
-        Width = 473
+        Width = 464
         HorzScrollBar.Page = 326
         VertScrollBar.Page = 437
         Anchors = [akTop, akLeft, akRight, akBottom]
         ClientHeight = 516
-        ClientWidth = 469
+        ClientWidth = 460
         TabOrder = 0
         object RadioGroup_BackupMode: TRadioGroup
           AnchorSideLeft.Control = ScrollBox_Sync
@@ -62,7 +103,7 @@ object FormOptions: TFormOptions
           Left = 0
           Height = 56
           Top = 135
-          Width = 459
+          Width = 450
           Anchors = [akTop, akLeft, akRight]
           AutoFill = True
           BorderSpacing.Top = 10
@@ -76,7 +117,7 @@ object FormOptions: TFormOptions
           ChildSizing.Layout = cclLeftToRightThenTopToBottom
           ChildSizing.ControlsPerLine = 3
           ClientHeight = 27
-          ClientWidth = 455
+          ClientWidth = 446
           Columns = 3
           Items.Strings = (
             '移动入库'
@@ -95,13 +136,13 @@ object FormOptions: TFormOptions
           Left = 0
           Height = 62
           Top = 201
-          Width = 459
+          Width = 450
           Anchors = [akTop, akLeft, akRight]
           BorderSpacing.Top = 10
           BorderSpacing.Right = 10
           Caption = '同步间隔'
           ClientHeight = 33
-          ClientWidth = 455
+          ClientWidth = 446
           TabOrder = 1
           object TrackBar_SyncInterval: TTrackBar
             AnchorSideLeft.Control = GroupBox_SyncInterval
@@ -112,7 +153,7 @@ object FormOptions: TFormOptions
             Left = 0
             Height = 26
             Top = 2
-            Width = 380
+            Width = 371
             Max = 20
             OnChange = TrackBar_SyncIntervalChange
             Position = 5
@@ -126,7 +167,7 @@ object FormOptions: TFormOptions
             AnchorSideTop.Side = asrCenter
             AnchorSideRight.Control = GroupBox_SyncInterval
             AnchorSideRight.Side = asrBottom
-            Left = 405
+            Left = 396
             Height = 24
             Top = 3
             Width = 40
@@ -145,13 +186,13 @@ object FormOptions: TFormOptions
           Left = 0
           Height = 164
           Top = 273
-          Width = 459
+          Width = 450
           Anchors = [akTop, akLeft, akRight]
           BorderSpacing.Top = 10
           BorderSpacing.Right = 10
           Caption = '同步规则'
           ClientHeight = 135
-          ClientWidth = 455
+          ClientWidth = 446
           TabOrder = 2
           object Memo_RegExpr: TMemo
             AnchorSideLeft.Control = GroupBox_SyncFilter
@@ -163,7 +204,7 @@ object FormOptions: TFormOptions
             Left = 0
             Height = 135
             Top = 0
-            Width = 455
+            Width = 446
             Anchors = [akTop, akLeft, akRight, akBottom]
             OnChange = Memo_RegExprChange
             ScrollBars = ssAutoVertical
@@ -179,13 +220,13 @@ object FormOptions: TFormOptions
           Left = 0
           Height = 72
           Top = 53
-          Width = 459
+          Width = 450
           Anchors = [akTop, akLeft, akRight]
           BorderSpacing.Top = 10
           BorderSpacing.Right = 10
           Caption = '同步路径：'
           ClientHeight = 43
-          ClientWidth = 455
+          ClientWidth = 446
           TabOrder = 3
           object Edit_SyncPath: TEdit
             AnchorSideLeft.Control = GroupBox_SyncPath
@@ -194,7 +235,7 @@ object FormOptions: TFormOptions
             Left = 10
             Height = 32
             Top = 5
-            Width = 350
+            Width = 341
             Anchors = [akTop, akLeft, akRight]
             BorderSpacing.Left = 10
             BorderSpacing.Top = 5
@@ -210,7 +251,7 @@ object FormOptions: TFormOptions
             AnchorSideRight.Side = asrBottom
             AnchorSideBottom.Control = Edit_SyncPath
             AnchorSideBottom.Side = asrBottom
-            Left = 370
+            Left = 361
             Height = 32
             Top = 5
             Width = 75
@@ -239,7 +280,7 @@ object FormOptions: TFormOptions
     object TabSheet_Format: TTabSheet
       Caption = '编辑属性'
       ClientHeight = 520
-      ClientWidth = 473
+      ClientWidth = 464
       object GroupBox_FormatEdit: TGroupBox
         AnchorSideLeft.Control = TabSheet_Format
         AnchorSideTop.Control = TabSheet_Format
@@ -248,13 +289,13 @@ object FormOptions: TFormOptions
         Left = 0
         Height = 297
         Top = 15
-        Width = 463
+        Width = 454
         Anchors = [akTop, akLeft, akRight]
         BorderSpacing.Top = 15
         BorderSpacing.Right = 10
         Caption = 'FormatEdit'
         ClientHeight = 268
-        ClientWidth = 459
+        ClientWidth = 450
         TabOrder = 0
         object CheckBox_FormatEditOpt_AllowBasicFormatEdit: TCheckBox
           AnchorSideLeft.Control = GroupBox_FormatEdit
@@ -316,7 +357,7 @@ object FormOptions: TFormOptions
     object TabSheet_Backup: TTabSheet
       Caption = '保存与备份'
       ClientHeight = 520
-      ClientWidth = 473
+      ClientWidth = 464
       object CheckBox_Backup_xml: TCheckBox
         AnchorSideLeft.Control = TabSheet_Backup
         AnchorSideTop.Control = TabSheet_Backup

--- a/forms/form_options.lfm
+++ b/forms/form_options.lfm
@@ -25,9 +25,9 @@ object FormOptions: TFormOptions
     Height = 557
     Top = 0
     Width = 481
-    ActivePage = TabSheet_Format
+    ActivePage = TabSheet_Backup
     Anchors = [akTop, akLeft, akRight, akBottom]
-    TabIndex = 2
+    TabIndex = 3
     TabOrder = 0
     object TabSheet_Summary: TTabSheet
       Caption = '总控制面板'

--- a/forms/form_options.pas
+++ b/forms/form_options.pas
@@ -29,12 +29,13 @@ type
     Memo_RegExpr: TMemo;
     PageControl_Option: TPageControl;
     CheckBox_SyncEnabled: TCheckBox;
+    RadioGroup_MGSC_CR: TRadioGroup;
     RadioGroup_BackupMode: TRadioGroup;
     ScrollBox_Sync: TScrollBox;
     SelectDirectoryDialog: TSelectDirectoryDialog;
     TabSheet_Backup: TTabSheet;
     TabSheet_Format: TTabSheet;
-    TabSheet_Summary: TTabSheet;
+    TabSheet_MaingridShortcut: TTabSheet;
     TabSheet_Sync: TTabSheet;
     TrackBar_SyncInterval: TTrackBar;
     procedure Button_SyncPathClick(Sender: TObject);
@@ -48,6 +49,7 @@ type
     procedure Memo_RegExprChange(Sender: TObject);
     procedure CheckBox_SyncEnabledChange(Sender: TObject);
     procedure RadioGroup_BackupModeClick(Sender: TObject);
+    procedure RadioGroup_MGSC_CRClick(Sender: TObject);
     procedure TrackBar_SyncIntervalChange(Sender: TObject);
   private
     TimerEnabled:boolean;//在OnShow和OnHide之间存储FormDesktop.SyncTimer.Enabled
@@ -111,6 +113,17 @@ begin
   CheckBox_Backup_xml.Checked:=FormDesktop.OptionMap.Backup_SaveXml;
   CheckBox_Fields_img.Checked:=FormDesktop.OptionMap.Fields_ImgFile;
   CheckBox_FormatEditOpt_ForceSave.Checked:=FormDesktop.OptionMap.ForceSaveField;
+  case FormDesktop.OptionMap.Shortcut_CtrlR of
+    mgsc_cc_title:RadioGroup_MGSC_CR.ItemIndex:=0;
+    mgsc_cc_path:RadioGroup_MGSC_CR.ItemIndex:=1;
+    mgsc_cc_link:RadioGroup_MGSC_CR.ItemIndex:=2;
+    mgsc_cc_gb7714:RadioGroup_MGSC_CR.ItemIndex:=3;
+    mgsc_cc_apa:RadioGroup_MGSC_CR.ItemIndex:=4;
+    mgsc_cc_mla:RadioGroup_MGSC_CR.ItemIndex:=5;
+    mgsc_cc_order:RadioGroup_MGSC_CR.ItemIndex:=6;
+    mgsc_cc_auyear:RadioGroup_MGSC_CR.ItemIndex:=7;
+    else RadioGroup_MGSC_CR.ItemIndex:=-1;
+  end;
 end;
 
 procedure TFormOptions.FormHide(Sender: TObject);
@@ -174,6 +187,27 @@ begin
   end;
 end;
 
+procedure TFormOptions.RadioGroup_MGSC_CRClick(Sender: TObject);
+var tmpCR:TMGSC_CR_Option;
+begin
+  with (Sender as TRadioGroup) do begin
+    case ItemIndex of
+      0:tmpCR:=mgsc_cc_title;
+      1:tmpCR:=mgsc_cc_path;
+      2:tmpCR:=mgsc_cc_link;
+      3:tmpCR:=mgsc_cc_gb7714;
+      4:tmpCR:=mgsc_cc_apa;
+      5:tmpCR:=mgsc_cc_mla;
+      6:tmpCR:=mgsc_cc_order;
+      7:tmpCR:=mgsc_cc_auyear;
+      else
+    end;
+  end;
+  FormDesktop.OptionMap.Shortcut_CtrlR:=tmpCR;
+  //if not ProjectInvalid then CurrentRTFP.RunPerformance.:=tmpCR;不涉及工程的设置
+
+end;
+
 procedure TFormOptions.LoadOptionFromReg;
 var Reg:TRegistry;
 begin
@@ -206,6 +240,15 @@ begin
     else
       begin
         FormDesktop.OptionMap.Backup_SaveXml:=false;
+      end;
+    if Reg.OpenKey('Software\ApiglioToolBox\RTFP_Desktop\ShortcutOption',false) then
+      begin
+        FormDesktop.OptionMap.Shortcut_CtrlR:=TMGSC_CR_Option(Reg.ReadInteger('Ctrl_R'));
+        Reg.CloseKey;
+      end
+    else
+      begin
+        FormDesktop.OptionMap.Shortcut_CtrlR:=mgsc_cc_gb7714;
       end;
     if Reg.OpenKey('Software\ApiglioToolBox\RTFP_Desktop\FieldsOption',false) then
       begin
@@ -242,6 +285,10 @@ begin
 
     Reg.OpenKey('Software\ApiglioToolBox\RTFP_Desktop\BackupOption',true);
     Reg.WriteBool('SaveXml',FormDesktop.OptionMap.Backup_SaveXml);
+    Reg.CloseKey;
+
+    Reg.OpenKey('Software\ApiglioToolBox\RTFP_Desktop\ShortcutOption',true);
+    Reg.WriteInteger('Ctrl_R',integer(FormDesktop.OptionMap.Shortcut_CtrlR));
     Reg.CloseKey;
 
     Reg.OpenKey('Software\ApiglioToolBox\RTFP_Desktop\FieldsOption',true);

--- a/forms/form_report_tool.pas
+++ b/forms/form_report_tool.pas
@@ -417,7 +417,7 @@ var bm:TBookMark;
 
 begin
   with CurrentRTFP.PaperDS do begin
-    rec_no:=RecNo;
+    rec_no:=RecordCount;
     img.Bitmap.Height:=cell_height*rec_no;
     pixel_width:=0;
     for pi:=0 to FieldDefs.Count-1 do begin

--- a/rtfp_core/aufunc.inc
+++ b/rtfp_core/aufunc.inc
@@ -169,6 +169,32 @@ begin
 
   CurrentRTFP.EditFieldAsString(AFieldName,AAttrName,APID,AMEMO,[aeCreateIfNoField,aeForceEditIfTypeDismatch]);
 end;
+procedure aufunc_EditImage(Sender:TObject);//attr.edit_image PID,AttrName,FieldName,filename
+var AufScpt:TAufScript;
+    AAuf:TAuf;
+    APID,filename,AFieldName,AAttrName:string;
+    APicture:TPicture;
+begin
+  AufScpt:=Sender as TAufScript;
+  AAuf:=AufScpt.Auf as TAuf;
+  if not AAuf.CheckArgs(5) then exit;
+  if not AAuf.TryArgToString(1,APID) then exit;
+  if not AAuf.TryArgToString(2,AAttrName) then exit;
+  if not AAuf.TryArgToString(3,AFieldName) then exit;
+  if not AAuf.TryArgToString(4,filename) then exit;
+
+  if not FileExists(filename) then begin
+    AufScpt.writeln('警告：找不到 '+filename+' 文件，'+Auf.args[0]+'未执行。');
+    exit
+  end;
+  APicture:=TPicture.Create;
+  try
+    APicture.LoadFromFile(filename);
+    CurrentRTFP.EditFieldAsBitmap(AFieldName,AAttrName,APID,APicture.Bitmap,[aeCreateIfNoField]);
+  finally
+    APicture.Free;
+  end;
+end;
 procedure aufunc_ReadAttr(Sender:TObject);//attr.read PID,AttrName,FieldName,out
 var AufScpt:TAufScript;
     AAuf:TAuf;
@@ -454,6 +480,35 @@ begin
         end;
         AF.FFieldDisplayOption.display_width:=slon;
       end;
+    'add_combo':
+      begin
+        if not AAuf.TryArgToString(4,stmp) then exit;
+        AG:=CurrentRTFP.FieldList.FindItemByName(NA);
+        if AG=nil then begin
+          AufScpt.send_error('错误：无属性组“'+NA+'”。');
+          exit;
+        end;
+        AF:=AG.FieldList.FindItemByName(NF);
+        if AF=nil then begin
+          AufScpt.send_error('错误：无属性“'+NF+'”。');
+          exit;
+        end;
+        AF.AddCombo(stmp);
+      end;
+    'clear_combo':
+      begin
+        AG:=CurrentRTFP.FieldList.FindItemByName(NA);
+        if AG=nil then begin
+          AufScpt.send_error('错误：无属性组“'+NA+'”。');
+          exit;
+        end;
+        AF:=AG.FieldList.FindItemByName(NF);
+        if AF=nil then begin
+          AufScpt.send_error('错误：无属性“'+NF+'”。');
+          exit;
+        end;
+        AF.ClearCombo;
+      end;
     else
       begin
         AufScpt.send_error('错误：key名称无意义。');
@@ -515,13 +570,14 @@ begin
     Script.add_func('paper.add',@aufunc_AddPaper,'filename,@out_pid,mode="fb"','新建Paper节点');
     Script.add_func('paper.del',@aufunc_DeletePaper,'PID','删除Paper节点');
 
-    Script.add_func('attrs.rec.edit',@aufunc_EditAttr,'PID,AttrName,FieldName,Memo','修改PID节点中第AttrNo表的FieldName字段为Memo');
-    Script.add_func('attrs.rec.read',@aufunc_ReadAttr,'PID,AttrName,FieldName,arv','修改PID节点中第AttrNo表的FieldName字段为Memo');
+    Script.add_func('attrs.rec.edit',@aufunc_EditAttr,'PID,AttrName,FieldName,Memo','修改PID节点中AttrName属性组的FieldName字段为Memo');
+    Script.add_func('attrs.rec.edit_image',@aufunc_EditImage,'PID,AttrName,FieldName,filename','修改PID节点中AttrName属性组的FieldName图像字段为filename图像');
+    Script.add_func('attrs.rec.read',@aufunc_ReadAttr,'PID,AttrName,FieldName,arv','修改PID节点中AttrName属性组的FieldName字段为Memo');
 
     //Script.add_func('attrs.ag.add',@aufunc_AddAttrGroup,'AttrName','在第AttrNo表中创建FieldName字段');
     //Script.add_func('attrs.ag.del',@aufunc_DelAttrGroup,'AttrName','在第AttrNo表中创建FieldName字段');
-    Script.add_func('attrs.af.add',@aufunc_AddAttrField,'AttrName,FieldName','在第AttrNo表中创建FieldName字段');
-    Script.add_func('attrs.af.del',@aufunc_DelAttrField,'AttrName,FieldName','在第AttrNo表中创建FieldName字段');
+    Script.add_func('attrs.af.add',@aufunc_AddAttrField,'AttrName,FieldName','在AttrName属性组中创建FieldName字段');
+    Script.add_func('attrs.af.del',@aufunc_DelAttrField,'AttrName,FieldName','在AttrName属性组中创建FieldName字段');
 
     Script.add_func('class.add',@aufunc_addKlass,'KlassName, Path','创建分类表');
     Script.add_func('class.del',@aufunc_DeleteKlass,'KlassName','删除分类表');

--- a/rtfp_core/aufunc.inc
+++ b/rtfp_core/aufunc.inc
@@ -22,6 +22,14 @@ begin
 end;
 }
 
+function intern_aufunc_sort_double(Item1,Item2:Pointer):integer;
+begin
+  sleep(1);
+  if double(Item1)<double(Item2) then result:=-1
+  else if double(Item1)>double(Item2) then result:=1
+  else result:=0;
+end;
+
 procedure aufunc_BeginUpdate(Sender:TObject);
 begin
   CurrentRTFP.BeginUpdate;
@@ -555,6 +563,75 @@ begin
     AufScpt.writeln('T') else AufScpt.writeln('F');
 end;
 
+{$define qsort}
+procedure aufunc_sort_test(Sender:TObject);
+var AufScpt:TAufScript;
+    AAuf:TAuf;
+    {$ifdef qsort}
+    AList:TList;
+    {$else}
+    sbt:TSortingBinaryTree;
+    ptr:Pointer;
+    {$endif}
+    pi,len:integer;
+
+begin
+  AufScpt:=Sender as TAufScript;
+  AAuf:=AufScpt.Auf as TAuf;
+  if not AAuf.CheckArgs(1) then exit;
+  if not AAuf.TryArgToLong(1,len) then exit;
+  {$ifdef qsort}
+  AList:=TList.Create;
+  {$else}
+  sbt:=TSortingBinaryTree.Create;
+  {$endif}
+  try
+    Randomize;
+    {$ifdef qsort}
+    for pi:=0 to len-1 do AList.Add(Pointer(random()));
+    AList.Sort(@intern_aufunc_sort_double);
+    {$else}
+    for pi:=0 to len-1 do sbt.Compare(Pointer(random()),@intern_aufunc_sort_double);
+    for ptr in sbt do ;
+    {$endif}
+  finally
+    {$ifdef qsort}
+    AList.Free;
+    {$else}
+    sbt.Free;
+    {$endif}
+  end;
+
+end;
+
+procedure aufunc_maingrid_sort(Sender:TObject);//update.sort field_name
+var AufScpt:TAufScript;
+    AAuf:TAuf;
+    arg_count,argi:byte;
+    fieldnames:array of string;
+    opt:TDataSetSortOption;
+begin
+  AufScpt:=Sender as TAufScript;
+  AAuf:=AufScpt.Auf as TAuf;
+  if not AAuf.CheckArgs(2) then exit;
+  arg_count:=AAuf.ArgsCount;
+  SetLength(fieldnames,arg_count-1);
+  try
+    for argi:=1 to arg_count-1 do
+      if not AAuf.TryArgToString(argi,fieldnames[argi-1]) then exit;
+    opt:=TDataSetSortOption.Create;
+    try
+      for argi:=1 to arg_count-1 do opt.Assign(fieldnames[argi-1],smAscending);
+      SortDataSet(CurrentRTFP.PaperDS,opt);
+    finally
+      opt.Free;
+    end;
+  finally
+    SetLength(fieldnames,0);
+  end;
+
+end;
+
 {$endif}
 
 procedure AufScriptFuncDefineRTFP(Auf:TAuf);
@@ -589,6 +666,7 @@ begin
 
     Script.add_func('update.begin',@aufunc_BeginUpdate,'filename','开始更新模式');
     Script.add_func('update.end',@aufunc_EndUpdate,'filename','结束更新模式');
+    Script.add_func('update.mg.sort',@aufunc_maingrid_sort,'*arg','主表按字段排序');
     Script.add_func('update.test',@aufunc_update_case,'mode','测试更新过程');
 
     Script.add_func('fmt.rebuild',@aufunc_RebuildFormatEdit,'filename','从filename中加载FormatEdit布局');
@@ -604,6 +682,9 @@ begin
 
     {$ifdef test}
     Script.add_func('test',@aufunc_test,'*arg','测试');
+    Script.add_func('sort_test',@aufunc_sort_test,'*arg','测试');
+
+
     {$endif}
 
   end;

--- a/rtfp_core/control_interface.inc
+++ b/rtfp_core/control_interface.inc
@@ -231,7 +231,7 @@ begin
       for klass in FKlassList do
         begin
           with klass.Dbf do begin
-            if not klass.FilterEnabled then continue;
+            if not RunPerformance.Klass_Filter_NOT xor klass.FilterEnabled then continue;
             if not Active then Open;
             First;
             while not EOF do
@@ -376,27 +376,30 @@ begin
 end;
 
 function CheckRegExpr(expr:string):boolean;
-var regg:TRegExpr;
+//var regg:TRegExpr;
 begin
   result:=false;
   if expr='' then exit;
-  regg:=TRegExpr.Create(expr);
+  //regg:=TRegExpr.Create{(expr)};
+  //try
   try
-    try
-      //regg.Expression:=expr;
-      if regg.Exec('-9~Ma中') then;
-      except exit;
-    end;
-  finally
-    regg.Free;
+    //regg.Expression:=expr;
+    //if regg.Exec('-9~Ma中') then;
+    rtfp_reg.Expression:=expr;
+    if rtfp_reg.Exec('-9~Ma中') then;
+  except
+    exit;
   end;
+  //finally
+    //regg.Free;
+  //end;
   result:=true;
 end;
 
 procedure TRTFP.TableFilter;
 var colname,method,value:string;
     col_num:integer;
-    regg:TRegExpr;
+    //regg:TRegExpr;
     cmd:string;
     bm:TBookMark;
     mem:TMemoryStream;
@@ -417,7 +420,7 @@ begin
   cmd:=RunPerformance.Filter_Command;
 
   if (not IsUpdating) and (FOnMainGridRebuilding<>nil) then FOnMainGridRebuilding(Self);
-  regg:=TRegExpr.Create;
+  //regg:=TRegExpr.Create;
   mem:=TMemoryStream.Create;
   BeginUpdate;
   bm:=FPaperDS.Bookmark;
@@ -447,7 +450,9 @@ begin
 
     case method of
       'true','false','valid':;
-      'reg':if CheckRegExpr(value) then regg.Expression:=value else exit;//主窗体的try except似乎没啥用，正则表达式不能判断错误，错误的表达式直接导致闪退
+      'reg':if CheckRegExpr(value) then rtfp_reg.Expression:=value else exit;
+      //'reg':if CheckRegExpr(value) then regg.Expression:=value else exit;
+      //主窗体的try except似乎没啥用，正则表达式不能判断错误，错误的表达式直接导致闪退
       else if FAuf.ArgsCount<3 then exit;
     end;
 
@@ -489,7 +494,8 @@ begin
               'gtq':if Fields[Col_num].AsLargeInt<Usf.to_f(value) then Delete else Next;
               'les':if Fields[Col_num].AsLargeInt>=Usf.to_f(value) then Delete else Next;
               'leq':if Fields[Col_num].AsLargeInt>Usf.to_f(value) then Delete else Next;
-              'reg':if not regg.Exec(Fields[Col_num].AsString) then Delete else Next;
+              //'reg':if not regg.Exec(Fields[Col_num].AsString) then Delete else Next;
+              'reg':if not rtfp_reg.Exec(Fields[Col_num].AsString) then Delete else Next;
               else exit;
             end;
           end;
@@ -500,7 +506,7 @@ begin
     FAuf.Script.IO_fptr.echo:=tmp_pfunc[2];
     if FPaperDS.BookmarkValid(bm) then FPaperDS.GotoBookmark(bm);
     EndUpdate;
-    regg.Free;
+    //regg.Free;
     mem.Free;
     if (not IsUpdating) and (FOnMainGridRebuildDone<>nil) then FOnMainGridRebuildDone(Self);
   end;

--- a/rtfp_core/control_interface.inc
+++ b/rtfp_core/control_interface.inc
@@ -397,9 +397,10 @@ procedure TRTFP.TableFilter;
 var colname,method,value:string;
     col_num:integer;
     regg:TRegExpr;
-    cmd,reg_temp:string;
+    cmd:string;
     bm:TBookMark;
     mem:TMemoryStream;
+    tmp_pfunc:array[0..2]of pFuncAufStr;
 begin
   //= eql         相等
   //!= <> neq     不相等
@@ -431,6 +432,9 @@ begin
     StringReplace(cmd,'<=',' leq ',[rfReplaceAll]);
     StringReplace(cmd,'=~',' reg ',[rfReplaceAll]);
 
+    tmp_pfunc[0]:=FAuf.Script.IO_fptr.error;
+    tmp_pfunc[1]:=FAuf.Script.IO_fptr.print;
+    tmp_pfunc[2]:=FAuf.Script.IO_fptr.echo;
     FAuf.Script.IO_fptr.error:=nil;
     FAuf.Script.IO_fptr.print:=nil;
     FAuf.Script.IO_fptr.echo:=nil;
@@ -491,6 +495,9 @@ begin
           end;
       end;
   finally
+    FAuf.Script.IO_fptr.error:=tmp_pfunc[0];
+    FAuf.Script.IO_fptr.print:=tmp_pfunc[1];
+    FAuf.Script.IO_fptr.echo:=tmp_pfunc[2];
     if FPaperDS.BookmarkValid(bm) then FPaperDS.GotoBookmark(bm);
     EndUpdate;
     regg.Free;
@@ -499,8 +506,148 @@ begin
   end;
 end;
 
+function DefaultDataSetCompare(Item1,Item2:TFields;DefsList:Tlist):Integer;
+var fid:integer;
+    function sgn(value:int64):integer;
+    begin
+      if value>0 then result:=1 else if value<0 then result:=-1 else result:=0;
+    end;
+    function DoCompare(Item1,Item2:TField):integer;
+    begin
+      case Item1.DataType of
+        ftInteger,ftLargeint,ftSmallint:
+          begin
+            if Item1.AsInteger>Item2.AsInteger then result:=1
+            else if Item1.AsInteger<Item2.AsInteger then result:=-1
+            else result:=0;
+          end;
+        ftFloat:
+          begin
+            if Item1.AsFloat>Item2.AsFloat then result:=1
+            else if Item1.AsFloat<Item2.AsFloat then result:=-1
+            else result:=0;
+          end;
+        ftString,ftMemo:result:=sgn(strcomp(pchar(Item1.AsString),pchar(Item2.AsString)));
+        ftBoolean:
+          begin
+            if Item1.AsBoolean and not Item2.AsBoolean then result:=1
+            else if not Item1.AsBoolean and Item2.AsBoolean then result:=-1
+            else result:=0;
+          end;
+      end;
+    end;
+begin
+  result:=0;
+  fid:=0;
+  while fid<DefsList.Count do begin
+    result:=DoCompare(Item1[TFieldDef(DefsList[fid]).Index],Item2[TFieldDef(DefsList[fid]).Index]);
+    if result<>0 then exit;
+    inc(fid);
+  end;
+end;
 
+procedure SortDataSet(DS:TDataSet;Compare:TDataSetCompare);
+var bound,maxo,pi,size:integer;
+    item:array[1..2]of TFields;
+    recn:array[1..2]of integer;//同时记录item的行号，如果对比相等则不重复复制
+    procedure load_fields(which,recno:integer);
+    begin
+      //if recn[which]<>recno then item[which]
+    end;
 
+begin
+  recn[1]:=-1;
+  recn[2]:=-1;
+  DS.RecNo:=0;
+  bound:=0;
+  maxo:=0;
+  size:=DS.RecordCount;
+  item[1]:=TFields.Create(nil);
+  item[2]:=TFields.Create(nil);
+  try
+    while bound<size-1 do begin
+      maxo:=bound;
+      for pi:=bound to size-1 do begin
+        //if Compare();
+      end;
+      inc(bound);
+    end;
+
+  finally
+    item[1].Free;
+    item[2].Free;
+  end;
+  //Compare(Item1,Item2,nil);
+end;
+
+procedure SortDataSet(DS:TDataSet);
+begin
+  SortDataSet(DS,@DefaultDataSetCompare);
+end;
+
+procedure TRTFP.TableSorter;
+var flist:TList;
+    fid:integer;
+    cmd,fstmp:string;
+    tmpDef:TFieldDef;
+    bm:TBookMark;
+    mem:TMemoryStream;
+    tmp_pfunc:array[0..2]of pFuncAufStr;
+begin
+
+  cmd:=RunPerformance.Filter_Command;
+
+  if (not IsUpdating) and (FOnMainGridRebuilding<>nil) then FOnMainGridRebuilding(Self);
+  mem:=TMemoryStream.Create;
+  flist:=TList.Create;
+  BeginUpdate;
+  bm:=FPaperDS.Bookmark;
+  try
+    tmp_pfunc[0]:=FAuf.Script.IO_fptr.error;
+    tmp_pfunc[1]:=FAuf.Script.IO_fptr.print;
+    tmp_pfunc[2]:=FAuf.Script.IO_fptr.echo;
+    FAuf.Script.IO_fptr.error:=nil;
+    FAuf.Script.IO_fptr.print:=nil;
+    FAuf.Script.IO_fptr.echo:=nil;
+    FAuf.ReadArgs(cmd);
+    if FAuf.ArgsCount<2 then exit;
+    fid:=0;
+    repeat
+      fstmp:=FAuf.nargs[fid].arg;
+      tmpDef:=FPaperDS.FieldDefs.Find(fstmp);
+      if tmpDef<>nil then flist.Add(tmpDef);
+      inc(fid);
+    until (fstmp='') or (fid>=32);
+    if flist.Count<=0 then exit;
+
+    fid:=0;
+    while fid<FPaperDS.FieldDefs.Count do
+      begin
+        if FPaperDS.FieldDefs[fid].Name=IntToStr(fid) then break;
+        inc(fid);
+      end;
+    if fid>=FPaperDS.FieldDefs.Count then exit;
+
+    with FPaperDS do
+      begin
+        if not Active then Open;//没有必要吧
+        First;
+        while not EOF do
+          begin
+
+          end;
+      end;
+  finally
+    FAuf.Script.IO_fptr.error:=tmp_pfunc[0];
+    FAuf.Script.IO_fptr.print:=tmp_pfunc[1];
+    FAuf.Script.IO_fptr.echo:=tmp_pfunc[2];
+    if FPaperDS.BookmarkValid(bm) then FPaperDS.GotoBookmark(bm);
+    EndUpdate;
+    mem.Free;
+    flist.Free;
+    if (not IsUpdating) and (FOnMainGridRebuildDone<>nil) then FOnMainGridRebuildDone(Self);
+  end;
+end;
 
 
 

--- a/rtfp_core/control_interface.inc
+++ b/rtfp_core/control_interface.inc
@@ -506,103 +506,21 @@ begin
   end;
 end;
 
-function DefaultDataSetCompare(Item1,Item2:TFields;DefsList:Tlist):Integer;
-var fid:integer;
-    function sgn(value:int64):integer;
-    begin
-      if value>0 then result:=1 else if value<0 then result:=-1 else result:=0;
-    end;
-    function DoCompare(Item1,Item2:TField):integer;
-    begin
-      case Item1.DataType of
-        ftInteger,ftLargeint,ftSmallint:
-          begin
-            if Item1.AsInteger>Item2.AsInteger then result:=1
-            else if Item1.AsInteger<Item2.AsInteger then result:=-1
-            else result:=0;
-          end;
-        ftFloat:
-          begin
-            if Item1.AsFloat>Item2.AsFloat then result:=1
-            else if Item1.AsFloat<Item2.AsFloat then result:=-1
-            else result:=0;
-          end;
-        ftString,ftMemo:result:=sgn(strcomp(pchar(Item1.AsString),pchar(Item2.AsString)));
-        ftBoolean:
-          begin
-            if Item1.AsBoolean and not Item2.AsBoolean then result:=1
-            else if not Item1.AsBoolean and Item2.AsBoolean then result:=-1
-            else result:=0;
-          end;
-      end;
-    end;
-begin
-  result:=0;
-  fid:=0;
-  while fid<DefsList.Count do begin
-    result:=DoCompare(Item1[TFieldDef(DefsList[fid]).Index],Item2[TFieldDef(DefsList[fid]).Index]);
-    if result<>0 then exit;
-    inc(fid);
-  end;
-end;
-
-procedure SortDataSet(DS:TDataSet;Compare:TDataSetCompare);
-var bound,maxo,pi,size:integer;
-    item:array[1..2]of TFields;
-    recn:array[1..2]of integer;//同时记录item的行号，如果对比相等则不重复复制
-    procedure load_fields(which,recno:integer);
-    begin
-      //if recn[which]<>recno then item[which]
-    end;
-
-begin
-  recn[1]:=-1;
-  recn[2]:=-1;
-  DS.RecNo:=0;
-  bound:=0;
-  maxo:=0;
-  size:=DS.RecordCount;
-  item[1]:=TFields.Create(nil);
-  item[2]:=TFields.Create(nil);
-  try
-    while bound<size-1 do begin
-      maxo:=bound;
-      for pi:=bound to size-1 do begin
-        //if Compare();
-      end;
-      inc(bound);
-    end;
-
-  finally
-    item[1].Free;
-    item[2].Free;
-  end;
-  //Compare(Item1,Item2,nil);
-end;
-
-procedure SortDataSet(DS:TDataSet);
-begin
-  SortDataSet(DS,@DefaultDataSetCompare);
-end;
-
-procedure TRTFP.TableSorter;
-var flist:TList;
-    fid:integer;
-    cmd,fstmp:string;
-    tmpDef:TFieldDef;
-    bm:TBookMark;
-    mem:TMemoryStream;
+procedure TRTFP.TableSorter;unimplemented;
+var sort_option:TDataSetSortOption;
+    field_count,field_no:byte;
+    mode:TDataSetSortMode;
+    stmp,cmd:string;
     tmp_pfunc:array[0..2]of pFuncAufStr;
 begin
 
-  cmd:=RunPerformance.Filter_Command;
+  cmd:=RunPerformance.Sorter_Command;
 
   if (not IsUpdating) and (FOnMainGridRebuilding<>nil) then FOnMainGridRebuilding(Self);
-  mem:=TMemoryStream.Create;
-  flist:=TList.Create;
   BeginUpdate;
-  bm:=FPaperDS.Bookmark;
+  //bm:=FPaperDS.Bookmark;//这个书签要单独找
   try
+    sort_option:=TDataSetSortOption.Create;
     tmp_pfunc[0]:=FAuf.Script.IO_fptr.error;
     tmp_pfunc[1]:=FAuf.Script.IO_fptr.print;
     tmp_pfunc[2]:=FAuf.Script.IO_fptr.echo;
@@ -610,41 +528,26 @@ begin
     FAuf.Script.IO_fptr.print:=nil;
     FAuf.Script.IO_fptr.echo:=nil;
     FAuf.ReadArgs(cmd);
-    if FAuf.ArgsCount<2 then exit;
-    fid:=0;
-    repeat
-      fstmp:=FAuf.nargs[fid].arg;
-      tmpDef:=FPaperDS.FieldDefs.Find(fstmp);
-      if tmpDef<>nil then flist.Add(tmpDef);
-      inc(fid);
-    until (fstmp='') or (fid>=32);
-    if flist.Count<=0 then exit;
-
-    fid:=0;
-    while fid<FPaperDS.FieldDefs.Count do
-      begin
-        if FPaperDS.FieldDefs[fid].Name=IntToStr(fid) then break;
-        inc(fid);
+    field_count:=FAuf.ArgsCount;
+    if field_count<1 then exit;
+    mode:=smAscending;
+    for field_no:=0 to field_count-1 do begin
+      if not FAuf.TryArgToString(field_no,stmp) then continue;
+      case lowercase(stmp) of
+        'a','升序','+','up':mode:=smAscending;
+        'd','降序','-','down':mode:=smDescending;
+        else sort_option.Assign(stmp,mode);
       end;
-    if fid>=FPaperDS.FieldDefs.Count then exit;
+    end;
 
-    with FPaperDS do
-      begin
-        if not Active then Open;//没有必要吧
-        First;
-        while not EOF do
-          begin
-
-          end;
-      end;
+    SortDataSet(FPaperDS,sort_option);
   finally
+    sort_option.Free;
     FAuf.Script.IO_fptr.error:=tmp_pfunc[0];
     FAuf.Script.IO_fptr.print:=tmp_pfunc[1];
     FAuf.Script.IO_fptr.echo:=tmp_pfunc[2];
-    if FPaperDS.BookmarkValid(bm) then FPaperDS.GotoBookmark(bm);
+    //if FPaperDS.BookmarkValid(bm) then FPaperDS.GotoBookmark(bm);
     EndUpdate;
-    mem.Free;
-    flist.Free;
     if (not IsUpdating) and (FOnMainGridRebuildDone<>nil) then FOnMainGridRebuildDone(Self);
   end;
 end;

--- a/rtfp_core/events.inc
+++ b/rtfp_core/events.inc
@@ -13,7 +13,7 @@ end;
 procedure TRTFP.EndUpdate;
 begin
   //IsUpdating:=false;
-  dec(FUpdatingLevel);
+  if FUpdatingLevel>0 then dec(FUpdatingLevel);
 end;
 
 procedure TRTFP.Change;

--- a/rtfp_core/formatedit_component.inc
+++ b/rtfp_core/formatedit_component.inc
@@ -43,6 +43,8 @@ var SplitterObj:TSplitter;
     index:integer;
     stmp,is_editable,str_editable:string;
     tmp:integer;
+    AG:TAttrsGroup;
+    AF:TAttrsField;
 begin
   assert(FFormatEditComponentList.Count=0,'FormatEditBuild之前需要FormatEditClear！');
   with FFormatEditComponentList do begin
@@ -80,11 +82,9 @@ begin
       if lowercase(is_editable)='editable' then begin
         FormatPanel.Editable:=true;
         str_editable:='';
-        //FormatPanel.BevelColor:=clGreen;//在formatEdit中重写Paint改颜色，目前临时用标题改好了
       end else begin
         FormatPanel.Editable:=false;
         str_editable:='(只读)';
-        //FormatPanel.BevelColor:=clRed;//在formatEdit中重写Paint改颜色，目前临时用标题改好了
       end;
 
       Add(FormatPanel);
@@ -92,6 +92,17 @@ begin
       FormatPanel.FieldName:=Auf.nargs[2].arg;
       FormatPanel.DisplayName:=Auf.nargs[3].arg;
       FormatPanel.TitleLabel.Caption:=Auf.nargs[3].arg+str_editable+': ';
+
+      if FormatPanel.ComponentType=TComboBox then begin
+        AG:=FFieldList.FindItemByName(FormatPanel.AttrsName);
+        if AG<>nil then begin
+          AF:=AG.FieldList.FindItemByName(FormatPanel.FieldName);
+          if AF<>nil then begin
+            for index:=0 to AF.ComboItem.Count-1 do TComboBox(FormatPanel.Component).Items.Add(AF.ComboItem[index]);
+          end;
+        end;
+      end;
+
       with FormatPanel do begin
         Parent:=AScrollBox;
         BeginUpdateBounds;

--- a/rtfp_core/formatedit_component.inc
+++ b/rtfp_core/formatedit_component.inc
@@ -98,7 +98,11 @@ begin
         if AG<>nil then begin
           AF:=AG.FieldList.FindItemByName(FormatPanel.FieldName);
           if AF<>nil then begin
-            for index:=0 to AF.ComboItem.Count-1 do TComboBox(FormatPanel.Component).Items.Add(AF.ComboItem[index]);
+            if AF.ComboItem.Count>0 then begin
+              for index:=0 to AF.ComboItem.Count-1 do TComboBox(FormatPanel.Component).Items.Add(AF.ComboItem[index]);
+            end else begin
+              TComboBox(FormatPanel.Component).Items.Add('');
+            end;
           end;
         end;
       end;
@@ -263,7 +267,7 @@ begin
             'TEdit':EditFieldAsString(FieldName,AttrsName,PID,AsString,[aeForceEditIfTypeDismatch]);
             'TMemo':EditFieldAsMemo(FieldName,AttrsName,PID,AsMemo,[]);
             'TCheckBox':EditFieldAsBoolean(FieldName,AttrsName,PID,AsBoolean,[]);
-            'TComboBox':EditFieldAsString(FieldName,AttrsName,PID,AsString,[]);
+            'TComboBox':EditFieldAsString(FieldName,AttrsName,PID,AsString,[aeForceEditIfTypeDismatch]);
             'TFmtImage':EditFieldAsBitmap(FieldName,AttrsName,PID,AsBitmap,[]);
             'TListBox':EditFieldAsMemo(FieldName,AttrsName,PID,AsMemo,[]);
           end;

--- a/rtfp_core/formatedit_list.inc
+++ b/rtfp_core/formatedit_list.inc
@@ -89,6 +89,30 @@ begin
   end;
   result:=true;
 end;
+
+function TRTFP.AddFormatDefault_SysMgr:boolean;
+var str:TStringList;
+    index:integer;
+begin
+  result:=false;
+  if not FFormatList.Find('sys.fmt',index) then FFormatList.Add('sys.fmt');
+  str:=TStringList.Create;
+  try
+
+    str.Add('edit "","'+_Col_Paper_Folder_+'","目录",0,70,"L","LM","uneditable"');
+    str.Add('list "'+_Attrs_Class_+'","'+_Col_class_DefaultCl_+'","分类",0,70,"LM","ML","uneditable"');
+    str.Add('edit "'+_Attrs_Notes_+'","'+_Col_notes_CreateTime_+'","入库时间",0,70,"ML","M","uneditable"');
+    str.Add('edit "'+_Attrs_Notes_+'","'+_Col_notes_ModifyTime_+'","最近修改",0,70,"M","MR","uneditable"');
+    str.Add('edit "'+_Attrs_Notes_+'","'+_Col_notes_CheckTime_+'","最近查询",0,70,"MR","RM","uneditable"');
+    str.Add('edit "'+_Attrs_Notes_+'","'+_Col_notes_User_+'","入库用户",0,70,"RM","R","uneditable"');
+
+    str.SaveToFile(Self.FFilePath+Self.FRootFolder+'\format\sys.fmt');
+  finally
+    str.Free;
+  end;
+  result:=true;
+end;
+
 //以下是默认属性的呈现，但是我还是把它禁用掉吧，或者至少加一个全局开关
 {
 edit "","文件大小","size",0,70,"L","LM",uneditable
@@ -167,6 +191,7 @@ begin
   LoadFormatEditList;
   if not FFormatList.Find('default.fmt',index) then AddFormatDefault;
   if not FFormatList.Find('all.fmt',index) then AddFormatDefault_All;
+  if not FFormatList.Find('sys.fmt',index) then AddFormatDefault_SysMgr;
   //FFormatList.SaveToFile(Self.FFilePath+Self.FRootFolder+'\format.dat');
   FormatListChange;
 end;

--- a/rtfp_core/rtfp_class.pas
+++ b/rtfp_core/rtfp_class.pas
@@ -182,45 +182,6 @@ begin
     end;
 end;
 
-{
-procedure TKlassList.LoadFromPath(APath:string='\';data_set_type:string='dbf');
-var tmpFileList:TRTFP_FileList;
-    stmp:TCollectionItem;
-    pathname,klassname:string;
-    ext:string;
-begin
-  assert(APath<>'','TRTFP_ClassList.LoadFromPath: APath=""');
-  if APath='' then exit;
-  Clear;
-  tmpFileList:=TRTFP_FileList.Create(nil,FFullPath+'\'+APath);
-  try
-    tmpFileList.BaseDir:=FFullPath+'\'+APath;
-    tmpFileList.RunDir;
-    for stmp in tmpFileList do
-      begin
-        pathname:=(stmp as TRTFP_FileItem).Name;
-        klassname:=ExtractFilename(pathname);
-
-        if (pos('.dbf',lowercase(pathname))<>length(pathname)-3)
-        and (pos('.buf',lowercase(pathname))<>length(pathname)-3) then continue;
-        if (pos('_run.dbf',lowercase(pathname))=length(pathname)-7) and (length(pathname)>7) then continue;
-
-        ext:=lowercase(ExtractFileExt(klassname));
-        case ext of
-          '.dbf','.buf':klassname:=Copy(klassname,1,length(klassname)-4);
-        end;
-        {if ext='.dbf' then }pathname:=Copy(pathname,1,length(pathname)-4);
-        //ShowMessage(klassname+#13#10+pathname);
-        Self.AddEx(APath+'\'+pathname,klassname);
-      end;
-
-  finally
-    tmpFileList.Free;
-  end;
-
-end;
-}
-
 procedure TKlassList.LoadFromPath(APath:string='\';data_set_type:string='dbf');
 var tmpFileList:TRTFP_FileList;
     stmp:TCollectionItem;

--- a/rtfp_core/rtfp_dataset_sorter.pas
+++ b/rtfp_core/rtfp_dataset_sorter.pas
@@ -1,0 +1,295 @@
+unit rtfp_dataset_sorter;
+
+{$mode objfpc}{$H+}
+//{$define ListDialogTest}
+
+interface
+
+uses
+  Classes, SysUtils,
+  {$ifdef ListDialogTest}
+  rtfp_dialog, rtfp_constants,
+  {$endif}
+  db;
+
+type
+  TDataSetSortMode = (smUnassigned,smAscending,smDescending);
+  TDataSetSortOption = class
+    FieldName:string;
+    SortMode:TDataSetSortMode;
+    NextOption:TObject;
+  public
+    constructor Create;
+    destructor Destroy; override;
+  public
+    procedure Assign(AFieldName:string;AMode:TDataSetSortMode);
+    procedure Clear;
+  end;
+  PDataSetSortFunc = function(Item1,Item2:Pointer;ds:TDataSet=nil;AOptions:TDataSetSortOption=nil):integer;
+  PFuncPtrStr = function(ptr:Pointer):string;
+
+  TSortingBinaryTreeEnumerator = class
+  private
+    FRoot:TObject;
+    FList:TList;
+    FPosition:integer;
+  private
+    procedure Recursion(ANode:TObject);
+  public
+    constructor Create(ARoot:TObject);
+    function GetCurrent:Pointer;
+    function MoveNext:Boolean;
+    property Current:Pointer read GetCurrent;
+  end;
+
+  TSortingBinaryTree = class
+  public
+    Item:Pointer;
+    Left:TObject;
+    Right:TObject;
+  public
+    constructor Create;
+    destructor Destroy;override;
+    procedure Compare(AItem:Pointer;ASortMethod:PDataSetSortFunc;ds:TDataSet=nil;AOptions:TDataSetSortOption=nil);
+    function ExportToString(AMethod:PFuncPtrStr):string;
+  public
+    function GetEnumerator:TSortingBinaryTreeEnumerator;
+  end;
+
+procedure SortDataSet(ds:TDataSet;DSSOption:TDataSetSortOption);
+
+implementation
+
+{ TDataSetSortOption }
+
+constructor TDataSetSortOption.Create;
+begin
+  inherited Create;
+  NextOption:=nil;
+  FieldName:='';
+  SortMode:=smUnassigned;
+end;
+
+destructor TDataSetSortOption.Destroy;
+begin
+  if Assigned(NextOption) then (NextOption as TDataSetSortOption).Free;
+  inherited Destroy;
+end;
+
+procedure TDataSetSortOption.Assign(AFieldName:string;AMode:TDataSetSortMode);
+var tmpDataSetSortOption:TDataSetSortOption;
+begin
+  if SortMode=smUnassigned then begin
+    FieldName:=AFieldName;
+    SortMode:=AMode;
+  end else begin
+    tmpDataSetSortOption:=TDataSetSortOption.Create;
+    NextOption:=tmpDataSetSortOption;
+    (NextOption as TDataSetSortOption).Assign(AFieldName,AMode);
+  end;
+end;
+
+procedure TDataSetSortOption.Clear;
+var tmpDataSetSortOption:TDataSetSortOption;
+begin
+  if not Assigned(NextOption) then begin
+    SortMode:=smUnassigned;
+  end else begin
+    (NextOption as TDataSetSortOption).Clear;
+    (NextOption as TDataSetSortOption).Free;
+  end;
+end;
+
+{ TSortingBinaryTreeEnumerator }
+
+procedure TSortingBinaryTreeEnumerator.Recursion(ANode:TObject);
+var tmpNode:TSortingBinaryTree;
+begin
+  tmpNode:=ANode as TSortingBinaryTree;
+  if tmpNode.Left<>nil then Recursion(tmpNode.Left);
+  FList.Add(tmpNode.Item);
+  if tmpNode.Right<>nil then Recursion(tmpNode.Right);
+end;
+
+constructor TSortingBinaryTreeEnumerator.Create(ARoot:TObject);
+begin
+  inherited Create;
+  FList:=TList.Create;
+  FRoot:=ARoot;
+  Recursion(ARoot);
+  FPosition:=-1;
+end;
+
+function TSortingBinaryTreeEnumerator.GetCurrent:Pointer;
+begin
+  result:=FList.Items[FPosition]
+end;
+
+function TSortingBinaryTreeEnumerator.MoveNext:Boolean;
+begin
+  result:=true;
+  inc(FPosition);
+  if FPosition<FList.Count then exit;
+  FList.Free;//返回false时释放FList内存
+  result:=false;
+end;
+
+
+{ SortingBinaryTree }
+
+constructor TSortingBinaryTree.Create;
+begin
+  inherited Create;
+  Left:=nil;
+  Right:=nil;
+  Item:=nil;
+end;
+
+destructor TSortingBinaryTree.Destroy;
+begin
+  if Left<>nil then FreeAndNil(Left);
+  if Right<>nil then FreeAndNil(Right);
+  inherited Destroy;
+end;
+
+procedure TSortingBinaryTree.Compare(AItem:Pointer;ASortMethod:PDataSetSortFunc;ds:TDataSet=nil;AOptions:TDataSetSortOption=nil);
+begin
+  if Item=nil then begin
+    Item:=AItem;
+    exit;
+  end;
+  case ASortMethod(AItem,Item,ds,AOptions) of
+    -1:begin
+      if Right=nil then begin
+        Right:=TSortingBinaryTree.Create;
+        (Right as TSortingBinaryTree).Item:=AItem;
+      end
+      else (Right as TSortingBinaryTree).Compare(AItem,ASortMethod,ds,AOptions);
+    end;
+    else begin
+      if Left=nil then begin
+        Left:=TSortingBinaryTree.Create;
+        (Left as TSortingBinaryTree).Item:=AItem;
+      end
+      else (Left as TSortingBinaryTree).Compare(AItem,ASortMethod,ds,AOptions);
+    end;
+  end;
+end;
+
+function TSortingBinaryTree.ExportToString(AMethod:PFuncPtrStr):string;
+var s1,s2:string;
+begin
+  s1:='null';
+  s2:='null';
+  if Left<>nil then
+    s1:=TSortingBinaryTree(Left).ExportToString(AMethod);
+  if Right<>nil then
+    s2:=TSortingBinaryTree(Right).ExportToString(AMethod);
+  if (s1=s2) and (s1='null') then result:=AMethod(Item)
+  else result:='{'+AMethod(Item)+':['+s1+','+s2+']}';
+end;
+
+function TSortingBinaryTree.GetEnumerator:TSortingBinaryTreeEnumerator;
+begin
+  Result:=TSortingBinaryTreeEnumerator.Create(Self);
+end;
+
+function Intern_DSSortMethod(Item1,Item2:Pointer;ds:TDataSet=nil;AOptions:TDataSetSortOption=nil):integer;
+var tmpDSSOption:TDataSetSortOption;
+    v1,v2:Variant;
+    reverse:integer;
+begin
+  result:=0;
+  tmpDSSOption:=AOptions;
+  while true do begin
+    if tmpDSSOption=nil then exit;
+    if ds.FieldByName(tmpDSSOption.FieldName)=nil then begin
+      tmpDSSOption:=tmpDSSOption.NextOption as TDataSetSortOption;
+      continue;
+    end;
+    if tmpDSSOption.SortMode<>smAscending then reverse:=1
+    else reverse:=-1;
+    ds.RecNo:=plongint(Item1)^+1;
+    v1:=ds.FieldByName(tmpDSSOption.FieldName).AsVariant;
+    ds.RecNo:=plongint(Item2)^+1;
+    v2:=ds.FieldByName(tmpDSSOption.FieldName).AsVariant;
+    if v1=v2 then begin
+      tmpDSSOption:=tmpDSSOption.NextOption as TDataSetSortOption;
+      continue;
+    end;
+    if v1>v2 then result:=reverse else result:=-reverse;
+    exit;
+  end;
+end;
+
+function temp_intern_ptr_str(ptr:Pointer):string;
+begin
+  result:=IntToStr(pLongint(ptr)^);
+end;
+
+procedure SortDataSet(ds:TDataSet;DSSOption:TDataSetSortOption);
+var index,index_sub,field_no,dssize,fdcount:longint;
+    binary_tree_sort:TSortingBinaryTree;
+    order,fixed_order:array of longint;
+    field_var:array of Variant;
+    ptr:Pointer;
+    {$ifdef ListDialogTest}
+    tmpStrList:TStringList;
+    {$endif}
+
+begin
+  if DSSOption=nil then exit;
+  dssize:=ds.RecordCount;
+  if dssize<=1 then exit;
+  fdcount:=ds.FieldCount;
+
+  binary_tree_sort:=TSortingBinaryTree.Create;
+  {$ifdef ListDialogTest}
+  tmpStrList:=TStringList.Create;
+  {$endif}
+  SetLength(order,dssize);
+  SetLength(fixed_order,dssize);
+  SetLength(field_var,fdcount);
+  for index:=0 to dssize-1 do fixed_order[index]:=index;//0就是nil，nil就相当于没有，还得整这一出。
+  try
+    for index:=0 to dssize-1 do begin
+      binary_tree_sort.Compare(@(fixed_order[index]),@Intern_DSSortMethod,ds,DSSOption);
+    end;
+    index:=0;
+    for ptr in binary_tree_sort do begin
+      order[index]:=plongint(ptr)^+1;
+      {$ifdef ListDialogTest}
+      ds.RecNo:=plongint(ptr)^+1;
+      tmpStrList.Add('CunID['+IntToStr(order[index])+']'+ds.FieldByName('编号(村落属性)').AsString);
+      {$endif}
+      inc(index);
+    end;
+    {$ifdef ListDialogTest}
+    ShowMsgEdit('','',binary_tree_sort.ExportToString(@temp_intern_ptr_str));
+    ShowMsgList('主表排序测试','sort_dateset_list: ',tmpStrList);
+    {$endif}
+    for index:=0 to dssize-1 do begin
+      ds.RecNo:=order[index];
+      for field_no:=0 to fdcount-1 do field_var[field_no]:=ds.Fields[field_no].AsVariant;
+      ds.Append;
+      for field_no:=0 to fdcount-1 do ds.Fields[field_no].AsVariant:=field_var[field_no];
+      ds.Post;
+      ds.RecNo:=order[index];
+      ds.Delete;
+      for index_sub:=index+1 to dssize-1 do
+        if order[index_sub]>=order[index] then
+          dec(order[index_sub]);
+    end;
+
+  finally
+    binary_tree_sort.Free;
+    SetLength(order,0);
+    SetLength(fixed_order,0);
+    {$ifdef ListDialogTest}
+    tmpStrList.Free;
+    {$endif}
+  end;
+end;
+
+end.
+

--- a/rtfp_core/rtfp_dataset_sorter.pas
+++ b/rtfp_core/rtfp_dataset_sorter.pas
@@ -197,13 +197,17 @@ end;
 function Intern_DSSortMethod(Item1,Item2:Pointer;ds:TDataSet=nil;AOptions:TDataSetSortOption=nil):integer;
 var tmpDSSOption:TDataSetSortOption;
     v1,v2:Variant;
-    reverse:integer;
+    reverse,fs,fi:integer;
+    no_field:boolean;
 begin
   result:=0;
   tmpDSSOption:=AOptions;
   while true do begin
     if tmpDSSOption=nil then exit;
-    if ds.FieldByName(tmpDSSOption.FieldName)=nil then begin
+    fs:=ds.FieldCount;
+    no_field:=true;
+    for fi:=0 to fs-1 do if ds.FieldDefs.Items[fi].Name=tmpDSSOption.FieldName then begin no_field:=false;break;end;
+    if no_field then begin
       tmpDSSOption:=tmpDSSOption.NextOption as TDataSetSortOption;
       continue;
     end;
@@ -233,9 +237,6 @@ var index,index_sub,field_no,dssize,fdcount:longint;
     order,fixed_order:array of longint;
     field_var:array of Variant;
     ptr:Pointer;
-    {$ifdef ListDialogTest}
-    tmpStrList:TStringList;
-    {$endif}
 
 begin
   if DSSOption=nil then exit;
@@ -244,9 +245,6 @@ begin
   fdcount:=ds.FieldCount;
 
   binary_tree_sort:=TSortingBinaryTree.Create;
-  {$ifdef ListDialogTest}
-  tmpStrList:=TStringList.Create;
-  {$endif}
   SetLength(order,dssize);
   SetLength(fixed_order,dssize);
   SetLength(field_var,fdcount);
@@ -258,16 +256,8 @@ begin
     index:=0;
     for ptr in binary_tree_sort do begin
       order[index]:=plongint(ptr)^+1;
-      {$ifdef ListDialogTest}
-      ds.RecNo:=plongint(ptr)^+1;
-      tmpStrList.Add('CunID['+IntToStr(order[index])+']'+ds.FieldByName('编号(村落属性)').AsString);
-      {$endif}
       inc(index);
     end;
-    {$ifdef ListDialogTest}
-    ShowMsgEdit('','',binary_tree_sort.ExportToString(@temp_intern_ptr_str));
-    ShowMsgList('主表排序测试','sort_dateset_list: ',tmpStrList);
-    {$endif}
     for index:=0 to dssize-1 do begin
       ds.RecNo:=order[index];
       for field_no:=0 to fdcount-1 do field_var[field_no]:=ds.Fields[field_no].AsVariant;
@@ -285,9 +275,6 @@ begin
     binary_tree_sort.Free;
     SetLength(order,0);
     SetLength(fixed_order,0);
-    {$ifdef ListDialogTest}
-    tmpStrList.Free;
-    {$endif}
   end;
 end;
 

--- a/rtfp_core/rtfp_definition.pas
+++ b/rtfp_core/rtfp_definition.pas
@@ -134,6 +134,10 @@ type
       Filter_AutoRun:boolean;
       Sorter_Command:string;
       Sorter_AutoRun:boolean;
+
+      Klass_Filter_NOT:boolean;
+      Klass_Filter_AND:boolean;//false则为OR
+
     end;
 
 
@@ -561,6 +565,7 @@ procedure AufScriptFuncDefineRTFP(Auf:TAuf);
 
 implementation
 uses RTFP_main, rtfp_field_convert, Zipper;
+var rtfp_reg:TRegExpr;
 
 {$I aufunc.inc}
 {$I events.inc}
@@ -1942,6 +1947,13 @@ begin
   ShellExecute(0,'open',pchar(linkage),'','',SW_NORMAL);
   {$endif}
 end;
+
+initialization
+
+  rtfp_reg:=TRegExpr.Create;
+
+finalization
+  rtfp_reg.Free;
 
 end.
 

--- a/rtfp_core/rtfp_definition.pas
+++ b/rtfp_core/rtfp_definition.pas
@@ -1,17 +1,16 @@
 //引用PDF里的图片
-//字段选项化，进度表可以是checkboxlist的形式
 //网页下载要研究一下JS
 //字段更新日志(有必要吗)
 //Memo字段的搜索
 //尽快将所有弹窗统一样式（在做了，有点小问题，按键中文或者自动布局还没有处理好）
-//TKlass准备增加一个TKlassGroup类，和Attrs一样格式，这样才能保证ACL_ListView可以不重新折叠
+//【真的有难度】TKlass准备增加一个TKlassGroup类，和Attrs一样格式，这样才能保证ACL_ListView可以不重新折叠
 //增加替换URL的加载模式用以适用不同的webvpn
 //FWaitForm加进度条
 //“待注脚知识元”
 //FormatEdit快捷键提交
 //截图转文字想想办法，试试内嵌python
 //单元格设色属性、分类与属性组折叠等界面属性需要储存
-//FormatEdit中的Image通道化不能立刻更新！！！              //procedure TFmtImage.BandSolo(band:byte);
+//【快别说了，整个功能用不了了】FormatEdit中的Image通道化不能立刻更新！！！//procedure TFmtImage.BandSolo(band:byte);
 //分类字段清除后字段数据还在dbf中，没有pack
 //我他妈服了，DBF的文件错误也太多了吧？？？？
 //异常关闭的恢复
@@ -23,18 +22,13 @@
 //  工程属性加一个简介给自己记录东西
 //  报表工具增加进度条工具，结合rtfp_dialog来做
 
-
 //KNOWN FEATURES
 //  图片FormatEdit编辑中所有都是NoData，有一张编辑成Saved以后其他所有也都会变成Saved，重新NodeValidate之后NoData就恢复了
 //  为什么AufScriptFrame的两个Dialog初始地址不能改？在projectOpenDone里头。
-//  导出图片报表目前需要将游标指向最后一行才能完整导出所有记录
 
 //KNOWN BUGS
-//  AufScript的输出不见了（这个应该来自于一个异常之后的问题）
-//  win11百度输入法覆盖输入时会有一个错误（暂时无法复现，可能也是上一个问题的情况）
 //  在主表中显示的字段不能直接删除，否则报错，出自RebuildMainGrid
 //  【FATAL】TableFilter中使用无效的正则表达式会导致崩溃，并且主窗体中try except不能解决问题
-//  执行了批量编辑图片的代码之后，UpdateCurrentPID开始不能正常运行，怀疑是update.begin的问题（应该已经解决好了）
 
 
 //{$define insert}

--- a/rtfp_core/rtfp_definition.pas
+++ b/rtfp_core/rtfp_definition.pas
@@ -26,13 +26,15 @@
 
 //KNOWN FEATURES
 //  图片FormatEdit编辑中所有都是NoData，有一张编辑成Saved以后其他所有也都会变成Saved，重新NodeValidate之后NoData就恢复了
-
+//  为什么AufScriptFrame的两个Dialog初始地址不能改？在projectOpenDone里头。
+//  导出图片报表目前需要将游标指向最后一行才能完整导出所有记录
 
 //KNOWN BUGS
 //  AufScript的输出不见了（这个应该来自于一个异常之后的问题）
 //  win11百度输入法覆盖输入时会有一个错误（暂时无法复现，可能也是上一个问题的情况）
 //  在主表中显示的字段不能直接删除，否则报错，出自RebuildMainGrid
 //  【FATAL】TableFilter中使用无效的正则表达式会导致崩溃，并且主窗体中try except不能解决问题
+//  执行了批量编辑图片的代码之后，UpdateCurrentPID开始不能正常运行，怀疑是update.begin的问题（应该已经解决好了）
 
 
 //{$define insert}
@@ -58,7 +60,7 @@ uses
 
   {$ifndef insert}
   Apiglio_Useful, auf_ram_var, rtfp_pdfobj, rtfp_files, rtfp_class, rtfp_field,
-  rtfp_constants, rtfp_type, rtfp_tags, rtfp_format_component, rtfp_dialog, rtfp_misc,
+  rtfp_constants, rtfp_type, rtfp_tags, rtfp_format_component, rtfp_dialog, rtfp_misc, rtfp_dataset_sorter,
   {$endif}
   BufDataset, xmldatapacketreader,
   db, dbf, dbf_common, dbf_fields, sqldb, memds;
@@ -86,8 +88,6 @@ type
   public
     RTFP:TObject;
   end;
-
-  TDataSetCompare=function(Item1,Item2:TFields;DefsList:Tlist):Integer;//用于SortDataSet
 
 
   TRTFP = class(TComponent)

--- a/rtfp_core/rtfp_definition.pas
+++ b/rtfp_core/rtfp_definition.pas
@@ -87,6 +87,9 @@ type
     RTFP:TObject;
   end;
 
+  TDataSetCompare=function(Item1,Item2:TFields;DefsList:Tlist):Integer;//用于SortDataSet
+
+
   TRTFP = class(TComponent)
   private
 
@@ -129,6 +132,8 @@ type
 
       Filter_Command:string;
       Filter_AutoRun:boolean;
+      Sorter_Command:string;
+      Sorter_AutoRun:boolean;
     end;
 
 
@@ -316,6 +321,7 @@ type
   public
     function AddFormatDefault:boolean;
     function AddFormatDefault_All:boolean;
+    function AddFormatDefault_SysMgr:boolean;
     function AddFormatEditNull(filename:string):boolean;
     function RenFormatEdit(filename,newname:string):boolean;
     function DelFormatEdit(filename:string):boolean;
@@ -363,6 +369,7 @@ type
     procedure RebuildMainGrid;
     procedure UpdateCurrentRec(PID:RTFP_ID);
     procedure TableFilter;
+    procedure TableSorter;
 
     procedure FieldListValidate(AListView:TListView);
     procedure KlassListValidate(AListView:TListView);
@@ -761,7 +768,11 @@ procedure TRTFP.LoadKlass;
 var tmpKlass:TKlass;
 begin
   //BeginUpdate;
-  FKlassList.LoadFromPath('class\');
+  case FDataSetType of
+    dstDBF:FKlassList.LoadFromPath('class\','dbf');
+    dstBUF:FKlassList.LoadFromPath('class\','buf');
+    else raise Exception.Create('无效DataSetType。');
+  end;
   for tmpKlass in FKlassList do
     begin
       if not OpenDbf(tmpKlass.FullPath,tmpKlass.Dbf) then

--- a/rtfp_core/rtfp_definition.pas
+++ b/rtfp_core/rtfp_definition.pas
@@ -1087,6 +1087,7 @@ procedure TRTFP.SaveProjectOption(filename:string='');
 var AG:TAttrsGroup;
     AF:TAttrsField;
     str:TStringList;
+    stmp:string;
     function con(boo:boolean):string;
     begin
       result:='off';
@@ -1104,6 +1105,8 @@ begin
           begin
             str.Add('option.attrs.set "'+AG.Name+'","'+AF.FieldName+'","visible",'+con(AF.Shown));
             str.Add('option.attrs.set "'+AG.Name+'","'+AF.FieldName+'","display_width",'+IntToStr(AF.FFieldDisplayOption.display_width));
+            if AF.IsCombo then for stmp in AF.ComboItem do
+              str.Add('option.attrs.set "'+AG.Name+'","'+AF.FieldName+'","add_combo",'+stmp);
           end;
       end;
     if filename='' then filename:='option.lay.auf';

--- a/rtfp_core/rtfp_field.pas
+++ b/rtfp_core/rtfp_field.pas
@@ -36,12 +36,14 @@ type
     FShown:boolean;
     FOnChangeVisibility:TNotifyEvent;
     FUpdating:boolean;
+    FComboItem:TStringList;
   public//暂时改成公共
     FFieldDisplayOption:TFieldDisplayOption;
   protected
     procedure SetShown(value:boolean);
   public
-    constructor Create(ACollection: TCollection);
+    constructor Create(ACollection: TCollection); override;
+    destructor Destroy; override;
     procedure BeginUpdate;
     procedure EndUpdate;
 
@@ -51,6 +53,14 @@ type
     property FieldName:string read FFieldName write FFieldName;
     property AttrsGroup:TAttrsGroup read FAttrsGroup;
     property FieldDisplayOption:TFieldDisplayOption read FFieldDisplayOption{ write FFieldDisplayOption};
+
+  protected
+    function GetIsCombo:boolean;
+  public
+    procedure ClearCombo;
+    procedure AddCombo(Item:string);
+    property IsCombo:boolean read GetIsCombo;
+    property ComboItem:TStringList read FComboItem write FComboItem;
   end;
 
   TAttrsFieldEnumerator = class(TCollectionEnumerator)
@@ -166,6 +176,13 @@ begin
   FOnChangeVisibility:=nil;
   FFieldDisplayOption.colorize_process:=nil;
   FFieldDisplayOption.display_width:=90;
+  FComboItem:=TStringList.Create;
+  FComboItem.Sorted:=true;
+end;
+destructor TAttrsField.Destroy;
+begin
+  FComboItem.Free;
+  inherited Destroy;
 end;
 
 procedure TAttrsField.BeginUpdate;
@@ -177,6 +194,23 @@ procedure TAttrsField.EndUpdate;
 begin
   FUpdating:=false;
 end;
+
+
+function TAttrsField.GetIsCombo:boolean;
+begin
+  result:=(FComboItem.Count>0);
+end;
+
+procedure TAttrsField.ClearCombo;
+begin
+  FComboItem.Clear;
+end;
+
+procedure TAttrsField.AddCombo(Item:string);
+begin
+  FComboItem.Add(Item);
+end;
+
 
 { TAttrsFieldEnumerator }
 

--- a/rtfp_core/rtfp_format_component.pas
+++ b/rtfp_core/rtfp_format_component.pas
@@ -95,6 +95,7 @@ type
   public
     procedure RestoreState;//Setter函数中包含了FState:=fesSaved，如果是还原字段数值则需要用这个方法
     property State:TFmtEditState read FState write SetState;
+    property ComponentType:TClass read FClass;
 
   public
     property AsBoolean:boolean read GetBool write SetBool;

--- a/rtfp_core/rtfp_format_component.pas
+++ b/rtfp_core/rtfp_format_component.pas
@@ -443,6 +443,7 @@ function TFormatEditPanel.GetString:string;
 begin
   case FClass.ClassName of
     'TEdit':result:=TEdit(FComponent).Caption;
+    'TComboBox':result:=TComboBox(FComponent).Caption;
     else result:='';
   end;
 end;
@@ -495,9 +496,19 @@ begin
   FState:=fesSaved;
 end;
 procedure TFormatEditPanel.SetString(value:string);
+var index:integer;
 begin
   case FClass.ClassName of
     'TEdit':TEdit(FComponent).Caption:=value;
+    'TComboBox':
+      begin
+        index:=TComboBox(FComponent).Items.IndexOf(value);
+        if index<0 then begin
+          TComboBox(FComponent).Caption:=value;
+        end else begin
+          TComboBox(FComponent).ItemIndex:=index;
+        end;
+      end;
   end;
   FState:=fesSaved;
 end;

--- a/rtfp_core/rtfp_type.pas
+++ b/rtfp_core/rtfp_type.pas
@@ -27,6 +27,10 @@ type
   TSimChkOptions = set of TSimChkOption;
   TRTFP_DataSetType = (dstDBF,dstBUF);
 
+  TMGSC_CR_Option = (mgsc_cc_unknown=0, mgsc_cc_title=1, mgsc_cc_path=2,
+                     mgsc_cc_link=3, mgsc_cc_gb7714=4, mgsc_cc_apa=5,
+                     mgsc_cc_mla=6, mgsc_cc_order=7, mgsc_cc_auyear=8);//数字不允许修改，只能增加，用于注册表
+
 
 implementation
 

--- a/rtfp_core/rtfp_type.pas
+++ b/rtfp_core/rtfp_type.pas
@@ -27,6 +27,7 @@ type
   TSimChkOptions = set of TSimChkOption;
   TRTFP_DataSetType = (dstDBF,dstBUF);
 
+
 implementation
 
 end.

--- a/rtfp_main.lfm
+++ b/rtfp_main.lfm
@@ -1066,7 +1066,7 @@ object FormDesktop: TFormDesktop
     object TabSheet_Node_PDF: TTabSheet
       Caption = 'PDF预览'
       ClientHeight = 152
-      ClientWidth = 789
+      ClientWidth = 741
       object Image_PDF_View: TImage
         AnchorSideLeft.Control = TabSheet_Node_PDF
         AnchorSideTop.Control = TabSheet_Node_PDF
@@ -1283,7 +1283,7 @@ object FormDesktop: TFormDesktop
     object TabSheet_Node_FormatEdit: TTabSheet
       Caption = '编辑属性(样式)'
       ClientHeight = 152
-      ClientWidth = 789
+      ClientWidth = 741
       object ScrollBox_Node_FormatEdit: TScrollBox
         AnchorSideLeft.Control = TabSheet_Node_FormatEdit
         AnchorSideTop.Control = TabSheet_Node_FormatEdit
@@ -1294,7 +1294,7 @@ object FormDesktop: TFormDesktop
         Left = 0
         Height = 116
         Top = 0
-        Width = 789
+        Width = 741
         HorzScrollBar.Page = 1
         HorzScrollBar.Visible = False
         VertScrollBar.Page = 1
@@ -1309,7 +1309,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Control = ComboBox_FormatEdit
         AnchorSideBottom.Control = ComboBox_FormatEdit
         AnchorSideBottom.Side = asrCenter
-        Left = 239
+        Left = 215
         Height = 28
         Top = 118
         Width = 90
@@ -1327,7 +1327,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Side = asrCenter
         AnchorSideBottom.Control = ComboBox_FormatEdit
         AnchorSideBottom.Side = asrCenter
-        Left = 459
+        Left = 435
         Height = 28
         Top = 118
         Width = 90
@@ -1345,7 +1345,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Side = asrCenter
         AnchorSideBottom.Control = TabSheet_Node_FormatEdit
         AnchorSideBottom.Side = asrBottom
-        Left = 334
+        Left = 310
         Height = 32
         Top = 116
         Width = 120
@@ -1362,7 +1362,7 @@ object FormDesktop: TFormDesktop
         AnchorSideLeft.Side = asrBottom
         AnchorSideBottom.Control = ComboBox_FormatEdit
         AnchorSideBottom.Side = asrCenter
-        Left = 554
+        Left = 530
         Height = 28
         Hint = '提交并查看下一条'
         Top = 118
@@ -1379,7 +1379,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Control = Button_FormatEditPost
         AnchorSideBottom.Control = ComboBox_FormatEdit
         AnchorSideBottom.Side = asrCenter
-        Left = 180
+        Left = 156
         Height = 28
         Hint = '提交并查看上一条'
         Top = 118

--- a/rtfp_main.lfm
+++ b/rtfp_main.lfm
@@ -1,7 +1,7 @@
 object FormDesktop: TFormDesktop
-  Left = 902
+  Left = 1048
   Height = 622
-  Top = 332
+  Top = 475
   Width = 1003
   AllowDropFiles = True
   Caption = 'RTFP Desktop'
@@ -138,7 +138,12 @@ object FormDesktop: TFormDesktop
           OnCellClick = DBGrid_MainCellClick
           OnColumnSized = DBGrid_MainColumnSized
           OnDrawColumnCell = DBGrid_MainDrawColumnCell
+          OnDragDrop = DBGrid_MainDragDrop
+          OnDragOver = DBGrid_MainDragOver
           OnKeyUp = DBGrid_MainKeyUp
+          OnMouseDown = DBGrid_MainMouseDown
+          OnMouseEnter = DBGrid_MainMouseEnter
+          OnMouseLeave = DBGrid_MainMouseLeave
           OnMouseUp = DBGrid_MainMouseUp
           OnMouseWheel = DBGrid_MainMouseWheel
         end
@@ -220,7 +225,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Control = TabSheet_Project_FormatEditMgr
         AnchorSideBottom.Control = SynEdit_FEMgr
         Left = 5
-        Height = 191
+        Height = 192
         Top = 5
         Width = 235
         Anchors = [akTop, akLeft, akBottom]
@@ -238,7 +243,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = SynEdit_FEMgr
         Left = 245
-        Height = 221
+        Height = 222
         Top = 5
         Width = 539
         Anchors = [akTop, akLeft, akRight, akBottom]
@@ -273,7 +278,7 @@ object FormDesktop: TFormDesktop
         Left = 215
         Height = 25
         Hint = '重命名样式'
-        Top = 201
+        Top = 202
         Width = 25
         Anchors = [akRight, akBottom]
         BorderSpacing.Left = 5
@@ -292,7 +297,7 @@ object FormDesktop: TFormDesktop
         Left = 185
         Height = 25
         Hint = '删除样式'
-        Top = 201
+        Top = 202
         Width = 25
         Anchors = [akRight, akBottom]
         BorderSpacing.Left = 5
@@ -311,7 +316,7 @@ object FormDesktop: TFormDesktop
         Left = 155
         Height = 25
         Hint = '新建样式'
-        Top = 201
+        Top = 202
         Width = 25
         Anchors = [akRight, akBottom]
         BorderSpacing.Right = 5
@@ -329,7 +334,7 @@ object FormDesktop: TFormDesktop
         AnchorSideBottom.Control = SynEdit_FEMgr
         Left = 5
         Height = 25
-        Top = 201
+        Top = 202
         Width = 85
         Anchors = [akTop, akLeft, akRight, akBottom]
         BorderSpacing.Left = 5
@@ -346,8 +351,8 @@ object FormDesktop: TFormDesktop
         AnchorSideBottom.Control = TabSheet_Project_FormatEditMgr
         AnchorSideBottom.Side = asrBottom
         Left = 5
-        Height = 90
-        Top = 231
+        Height = 89
+        Top = 232
         Width = 779
         BorderSpacing.Left = 5
         BorderSpacing.Right = 5
@@ -853,7 +858,7 @@ object FormDesktop: TFormDesktop
         AnchorSideBottom.Control = SynEdit_FEMgr
         Left = 125
         Height = 25
-        Top = 201
+        Top = 202
         Width = 25
         Anchors = [akRight, akBottom]
         BorderSpacing.Right = 5
@@ -867,7 +872,7 @@ object FormDesktop: TFormDesktop
         AnchorSideBottom.Control = SynEdit_FEMgr
         Left = 95
         Height = 25
-        Top = 201
+        Top = 202
         Width = 25
         Anchors = [akRight, akBottom]
         BorderSpacing.Right = 5
@@ -880,41 +885,41 @@ object FormDesktop: TFormDesktop
     object TabSheet_Project_AufScript: TTabSheet
       Caption = '脚本'
       ClientHeight = 326
-      ClientWidth = 758
+      ClientWidth = 789
       OnResize = TabSheet_Project_AufScriptResize
       inline Frame_AufScript1: TFrame_AufScript
         Height = 326
-        Width = 758
+        Width = 789
         Align = alClient
         ClientHeight = 326
-        ClientWidth = 758
+        ClientWidth = 789
         inherited ProgressBar: TProgressBar
           AnchorSideLeft.Control = Frame_AufScript1
           AnchorSideRight.Control = Frame_AufScript1
           AnchorSideBottom.Control = Frame_AufScript1
           Height = 12
           Top = 309
-          Width = 748
+          Width = 779
         end
         inherited Memo_out: TMemo
           AnchorSideRight.Control = Frame_AufScript1
-          Left = 494
+          Left = 525
           Height = 242
           Top = 30
           Width = 259
         end
         inherited Button_run: TButton
-          Left = 494
+          Left = 525
           Top = 277
           Width = 85
         end
         inherited Button_pause: TButton
-          Left = 581
+          Left = 612
           Top = 277
           Width = 85
         end
         inherited Button_stop: TButton
-          Left = 668
+          Left = 699
           Top = 277
           Width = 85
         end
@@ -934,9 +939,6 @@ object FormDesktop: TFormDesktop
           Width = 299
           Gutter.Width = 61
           inherited SynLeftGutterPartList1: TSynGutterPartList
-            inherited SynGutterLineNumber1: TSynGutterLineNumber
-              Width = 19
-            end
             inherited SynGutterCodeFolding1: TSynGutterCodeFolding
               AutoSize = False
               Width = 12
@@ -948,7 +950,7 @@ object FormDesktop: TFormDesktop
           AnchorSideTop.Control = Frame_AufScript1
           AnchorSideRight.Control = Frame_AufScript1
           Height = 20
-          Width = 748
+          Width = 779
         end
         inherited OpenDialog: TOpenDialog
           left = 350
@@ -999,9 +1001,9 @@ object FormDesktop: TFormDesktop
     Height = 189
     Top = 369
     Width = 797
-    ActivePage = TabSheet_Node_FormatEdit
+    ActivePage = TabSheet_FmtCmt
     Anchors = [akTop, akLeft, akRight, akBottom]
-    TabIndex = 2
+    TabIndex = 1
     TabOrder = 4
     OnChange = PageControl_NodeChange
     object TabSheet_Node_PDF: TTabSheet
@@ -1016,7 +1018,7 @@ object FormDesktop: TFormDesktop
         Left = 0
         Height = 152
         Top = 0
-        Width = 208
+        Width = 200
         Anchors = [akTop, akLeft, akBottom]
       end
     end
@@ -1409,10 +1411,13 @@ object FormDesktop: TFormDesktop
         Font.CharSet = ANSI_CHARSET
         Font.Pitch = fpFixed
         Font.Quality = fqDraft
+        HideSelection = False
         ParentFont = False
         PopupMenu = PopupMenu_ClassManager
         ReadOnly = True
         TabOrder = 0
+        OnDragDrop = AListView_KlassDragDrop
+        OnDragOver = AListView_KlassDragOver
         OnNodeChecked = AListView_KlassNodeChecked
       end
       object Button_AddKlass: TButton

--- a/rtfp_main.lfm
+++ b/rtfp_main.lfm
@@ -1,7 +1,7 @@
 object FormDesktop: TFormDesktop
-  Left = 1048
+  Left = 908
   Height = 622
-  Top = 475
+  Top = 455
   Width = 1003
   AllowDropFiles = True
   Caption = 'RTFP Desktop'
@@ -44,10 +44,10 @@ object FormDesktop: TFormDesktop
     AnchorSideRight.Control = Owner
     AnchorSideRight.Side = asrBottom
     AnchorSideBottom.Control = Splitter_RightH
-    Left = 206
+    Left = 254
     Height = 363
     Top = 0
-    Width = 797
+    Width = 749
     ActivePage = TabSheet_Project_DataGrid
     Anchors = [akTop, akLeft, akRight, akBottom]
     TabIndex = 1
@@ -98,7 +98,7 @@ object FormDesktop: TFormDesktop
     object TabSheet_Project_DataGrid: TTabSheet
       Caption = '文献节点'
       ClientHeight = 326
-      ClientWidth = 789
+      ClientWidth = 741
       object Panel_DBGridMain: TPanel
         AnchorSideLeft.Control = TabSheet_Project_DataGrid
         AnchorSideTop.Control = TabSheet_Project_DataGrid
@@ -109,29 +109,28 @@ object FormDesktop: TFormDesktop
         Left = 0
         Height = 326
         Top = 0
-        Width = 789
+        Width = 741
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Panel_DBGridMain'
         ClientHeight = 326
-        ClientWidth = 789
+        ClientWidth = 741
         TabOrder = 0
         object DBGrid_Main: TDBGrid
           AnchorSideLeft.Control = Panel_DBGridMain
           AnchorSideTop.Control = Panel_DBGridMain
           AnchorSideRight.Control = Panel_DBGridMain
           AnchorSideRight.Side = asrBottom
-          AnchorSideBottom.Control = Panel_DBGridMain
-          AnchorSideBottom.Side = asrBottom
+          AnchorSideBottom.Control = Edit_DBGridMain_Sorter
           Left = 1
-          Height = 296
+          Height = 260
           Top = 1
-          Width = 787
+          Width = 739
           Anchors = [akTop, akLeft, akRight, akBottom]
-          BorderSpacing.Bottom = 28
           Color = clWindow
           Columns = <>
           DataSource = DataSource_Main
           Options = [dgTitles, dgIndicator, dgColumnResize, dgColLines, dgRowLines, dgTabs, dgRowSelect, dgAlwaysShowSelection, dgConfirmDelete, dgCancelOnExit, dgAnyButtonCanSelect, dgDblClickAutoSize]
+          ParentFont = False
           PopupMenu = PopupMenu_MainDBGrid
           ReadOnly = True
           TabOrder = 0
@@ -155,7 +154,7 @@ object FormDesktop: TFormDesktop
           Left = 71
           Height = 32
           Top = 293
-          Width = 583
+          Width = 535
           Anchors = [akLeft, akRight, akBottom]
           BorderSpacing.Left = 70
           BorderSpacing.Right = 5
@@ -188,7 +187,7 @@ object FormDesktop: TFormDesktop
           AnchorSideRight.Side = asrBottom
           AnchorSideBottom.Control = Edit_DBGridMain_Filter
           AnchorSideBottom.Side = asrBottom
-          Left = 728
+          Left = 680
           Height = 32
           Top = 293
           Width = 60
@@ -201,7 +200,7 @@ object FormDesktop: TFormDesktop
           AnchorSideTop.Control = Edit_DBGridMain_Filter
           AnchorSideTop.Side = asrCenter
           AnchorSideRight.Control = Button_MainFilter
-          Left = 659
+          Left = 611
           Height = 28
           Top = 295
           Width = 64
@@ -210,6 +209,64 @@ object FormDesktop: TFormDesktop
           Caption = '自动'
           OnClick = CheckBox_MainFilterAutoClick
           TabOrder = 3
+        end
+        object Edit_DBGridMain_Sorter: TEdit
+          AnchorSideLeft.Control = Panel_DBGridMain
+          AnchorSideRight.Control = CheckBox_MainSorterAuto
+          AnchorSideBottom.Control = Edit_DBGridMain_Filter
+          Left = 71
+          Height = 32
+          Top = 261
+          Width = 535
+          Anchors = [akLeft, akRight, akBottom]
+          BorderSpacing.Left = 70
+          BorderSpacing.Right = 5
+          OnChange = Edit_DBGridMain_SorterChange
+          OnKeyDown = Edit_DBGridMain_SorterKeyDown
+          TabOrder = 4
+          Text = '"PID"'
+        end
+        object Label_MainSorter: TLabel
+          AnchorSideLeft.Control = Panel_DBGridMain
+          AnchorSideTop.Control = Edit_DBGridMain_Sorter
+          AnchorSideTop.Side = asrCenter
+          Left = 6
+          Height = 24
+          Hint = '按顺序输入主表中的字段名，用半角双引号包括在内，用空格或逗号间隔。'
+          Top = 265
+          Width = 52
+          BorderSpacing.Left = 5
+          Caption = 'Sorter'
+          ParentColor = False
+        end
+        object CheckBox_MainSorterAuto: TCheckBox
+          AnchorSideTop.Control = Edit_DBGridMain_Sorter
+          AnchorSideTop.Side = asrCenter
+          AnchorSideRight.Control = Button_MainSorter
+          Left = 611
+          Height = 28
+          Top = 263
+          Width = 64
+          Anchors = [akTop, akRight]
+          BorderSpacing.Right = 5
+          Caption = '自动'
+          OnClick = CheckBox_MainSorterAutoClick
+          TabOrder = 5
+        end
+        object Button_MainSorter: TButton
+          AnchorSideTop.Control = Edit_DBGridMain_Sorter
+          AnchorSideRight.Control = DBGrid_Main
+          AnchorSideRight.Side = asrBottom
+          AnchorSideBottom.Control = Edit_DBGridMain_Sorter
+          AnchorSideBottom.Side = asrBottom
+          Left = 680
+          Height = 32
+          Top = 261
+          Width = 60
+          Anchors = [akTop, akRight, akBottom]
+          Caption = '排序'
+          OnClick = Button_MainSorterClick
+          TabOrder = 6
         end
       end
     end
@@ -966,7 +1023,7 @@ object FormDesktop: TFormDesktop
   object Splitter_MainV: TSplitter
     AnchorSideTop.Control = Owner
     AnchorSideBottom.Control = StatusBar
-    Left = 200
+    Left = 248
     Height = 558
     Top = 0
     Width = 6
@@ -980,10 +1037,10 @@ object FormDesktop: TFormDesktop
     AnchorSideRight.Control = Owner
     AnchorSideRight.Side = asrBottom
     Cursor = crVSplit
-    Left = 206
+    Left = 254
     Height = 6
     Top = 363
-    Width = 797
+    Width = 749
     Align = alNone
     Anchors = [akLeft, akRight]
     ResizeAnchor = akTop
@@ -997,10 +1054,10 @@ object FormDesktop: TFormDesktop
     AnchorSideRight.Control = Owner
     AnchorSideRight.Side = asrBottom
     AnchorSideBottom.Control = StatusBar
-    Left = 206
+    Left = 254
     Height = 189
     Top = 369
-    Width = 797
+    Width = 749
     ActivePage = TabSheet_FmtCmt
     Anchors = [akTop, akLeft, akRight, akBottom]
     TabIndex = 1
@@ -1025,13 +1082,13 @@ object FormDesktop: TFormDesktop
     object TabSheet_FmtCmt: TTabSheet
       Caption = '编辑属性(单个)'
       ClientHeight = 152
-      ClientWidth = 789
+      ClientWidth = 741
       object Button_FmtCmt_Post: TButton
         AnchorSideLeft.Control = ComboBox_AttrName
         AnchorSideRight.Control = TabSheet_FmtCmt
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = Button_FmtCmt_Recover
-        Left = 642
+        Left = 594
         Height = 32
         Top = 68
         Width = 142
@@ -1049,7 +1106,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = TabSheet_FmtCmt
         AnchorSideBottom.Side = asrBottom
-        Left = 642
+        Left = 594
         Height = 32
         Top = 110
         Width = 142
@@ -1070,7 +1127,7 @@ object FormDesktop: TFormDesktop
         Left = 0
         Height = 152
         Top = 0
-        Width = 564
+        Width = 516
         Anchors = [akTop, akLeft, akRight, akBottom]
         BorderSpacing.Right = 225
         OnChange = Memo_FmtCmtChange
@@ -1082,7 +1139,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Control = TabSheet_FmtCmt
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = ComboBox_FieldName
-        Left = 642
+        Left = 594
         Height = 32
         Top = -16
         Width = 112
@@ -1102,7 +1159,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Control = TabSheet_FmtCmt
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = Button_FmtCmt_Post
-        Left = 642
+        Left = 594
         Height = 32
         Top = 26
         Width = 112
@@ -1122,7 +1179,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Control = ComboBox_AttrName
         AnchorSideTop.Side = asrCenter
         AnchorSideRight.Control = ComboBox_AttrName
-        Left = 574
+        Left = 526
         Height = 21
         Top = -10
         Width = 68
@@ -1134,7 +1191,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Control = ComboBox_FieldName
         AnchorSideTop.Side = asrCenter
         AnchorSideRight.Control = ComboBox_FieldName
-        Left = 574
+        Left = 526
         Height = 21
         Top = 32
         Width = 68
@@ -1145,7 +1202,7 @@ object FormDesktop: TFormDesktop
       object Label_FmtCmtPID: TLabel
         AnchorSideLeft.Control = StaticText_AttrNameCombo
         AnchorSideTop.Control = Button_FmtCmt_Post
-        Left = 574
+        Left = 526
         Height = 24
         Top = 98
         Width = 66
@@ -1158,7 +1215,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Control = ComboBox_FieldName
         AnchorSideRight.Control = TabSheet_FmtCmt
         AnchorSideRight.Side = asrBottom
-        Left = 760
+        Left = 712
         Height = 24
         Hint = '该字段不支持FmtCmt'
         Top = 28
@@ -1189,7 +1246,7 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Control = ComboBox_FieldName
         AnchorSideRight.Control = TabSheet_FmtCmt
         AnchorSideRight.Side = asrBottom
-        Left = 760
+        Left = 712
         Height = 24
         Hint = '该字段支持FmtCmt'
         Top = 28
@@ -1354,7 +1411,7 @@ object FormDesktop: TFormDesktop
     Left = 0
     Height = 6
     Top = 0
-    Width = 200
+    Width = 248
     Align = alNone
     Anchors = [akTop, akLeft, akRight]
     ResizeAnchor = akTop
@@ -1369,20 +1426,20 @@ object FormDesktop: TFormDesktop
     Left = 0
     Height = 552
     Top = 6
-    Width = 200
-    ActivePage = TabSheet_Filter_Field
+    Width = 248
+    ActivePage = TabSheet_Filter_Klass
     Anchors = [akTop, akLeft, akRight, akBottom]
     Constraints.MinWidth = 200
     Font.CharSet = ANSI_CHARSET
     Font.Pitch = fpFixed
     Font.Quality = fqDraft
     ParentFont = False
-    TabIndex = 1
+    TabIndex = 0
     TabOrder = 7
     object TabSheet_Filter_Klass: TTabSheet
       Caption = '分类节点'
       ClientHeight = 515
-      ClientWidth = 192
+      ClientWidth = 240
       Font.CharSet = ANSI_CHARSET
       Font.Pitch = fpFixed
       Font.Quality = fqDraft
@@ -1392,12 +1449,12 @@ object FormDesktop: TFormDesktop
         AnchorSideTop.Control = TabSheet_Filter_Klass
         AnchorSideRight.Control = TabSheet_Filter_Klass
         AnchorSideRight.Side = asrBottom
-        AnchorSideBottom.Control = TabSheet_Filter_Klass
+        AnchorSideBottom.Control = RadioButton_KlassOR
         AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 479
+        Height = 442
         Top = 0
-        Width = 192
+        Width = 240
         Anchors = [akTop, akLeft, akRight, akBottom]
         AutoSort = False
         BorderSpacing.Bottom = 36
@@ -1425,7 +1482,7 @@ object FormDesktop: TFormDesktop
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Control = TabSheet_Filter_Klass
         AnchorSideBottom.Side = asrBottom
-        Left = 166
+        Left = 214
         Height = 26
         Hint = '长度限制在40个字节（约13个汉字），'#13#10'可使用的特殊符号包括：()_-+&"'':'
         Top = 484
@@ -1447,7 +1504,7 @@ object FormDesktop: TFormDesktop
         Left = 56
         Height = 32
         Top = 478
-        Width = 110
+        Width = 158
         Anchors = [akLeft, akRight, akBottom]
         BorderSpacing.Bottom = 5
         TabOrder = 2
@@ -1465,6 +1522,50 @@ object FormDesktop: TFormDesktop
         BorderSpacing.Bottom = 5
         Caption = '分类：'
         ParentColor = False
+      end
+      object CheckBox_KlassNot: TCheckBox
+        AnchorSideLeft.Control = RadioButton_KlassOR
+        AnchorSideLeft.Side = asrBottom
+        AnchorSideBottom.Control = RadioButton_KlassOR
+        AnchorSideBottom.Side = asrCenter
+        Left = 152
+        Height = 28
+        Top = 450
+        Width = 64
+        Anchors = [akLeft, akBottom]
+        Caption = '取反'
+        Enabled = False
+        TabOrder = 3
+      end
+      object RadioButton_KlassAND: TRadioButton
+        AnchorSideRight.Control = RadioButton_KlassOR
+        AnchorSideBottom.Control = RadioButton_KlassOR
+        AnchorSideBottom.Side = asrCenter
+        Left = 24
+        Height = 28
+        Top = 450
+        Width = 64
+        Anchors = [akRight, akBottom]
+        Caption = '交集'
+        Enabled = False
+        OnClick = RadioButton_KlassANDClick
+        TabOrder = 4
+      end
+      object RadioButton_KlassOR: TRadioButton
+        AnchorSideLeft.Control = TabSheet_Filter_Klass
+        AnchorSideLeft.Side = asrCenter
+        AnchorSideBottom.Control = Edit_AddKlass
+        Left = 88
+        Height = 28
+        Top = 450
+        Width = 64
+        Anchors = [akLeft, akBottom]
+        Caption = '并集'
+        Checked = True
+        Enabled = False
+        OnClick = RadioButton_KlassORClick
+        TabOrder = 5
+        TabStop = True
       end
     end
     object TabSheet_Filter_Field: TTabSheet
@@ -1975,8 +2076,8 @@ object FormDesktop: TFormDesktop
     end
   end
   object PopupMenu_ClassManager: TPopupMenu
-    left = 88
-    top = 352
+    left = 96
+    top = 304
     object MenuItem_ClassMgr_Del: TMenuItem
       Caption = '删除分类'
       OnClick = MenuItem_ClassMgr_DelClick
@@ -2004,8 +2105,8 @@ object FormDesktop: TFormDesktop
     end
   end
   object PopupMenu_FieldManager: TPopupMenu
-    left = 88
-    top = 392
+    left = 96
+    top = 352
     object MenuItem_FieldMgr_Edit: TMenuItem
       Caption = '字段设置'
       OnClick = MenuItem_FieldMgr_EditClick

--- a/rtfp_main.lfm
+++ b/rtfp_main.lfm
@@ -234,9 +234,9 @@ object FormDesktop: TFormDesktop
           Height = 24
           Hint = '按顺序输入主表中的字段名，用半角双引号包括在内，用空格或逗号间隔。'
           Top = 265
-          Width = 52
+          Width = 56
           BorderSpacing.Left = 5
-          Caption = 'Sorter'
+          Caption = 'Sorter:'
           ParentColor = False
         end
         object CheckBox_MainSorterAuto: TCheckBox
@@ -1534,7 +1534,7 @@ object FormDesktop: TFormDesktop
         Width = 64
         Anchors = [akLeft, akBottom]
         Caption = '取反'
-        Enabled = False
+        OnClick = CheckBox_KlassNotClick
         TabOrder = 3
       end
       object RadioButton_KlassAND: TRadioButton

--- a/rtfp_main.lfm
+++ b/rtfp_main.lfm
@@ -1,7 +1,7 @@
 object FormDesktop: TFormDesktop
-  Left = 824
+  Left = 902
   Height = 622
-  Top = 327
+  Top = 332
   Width = 1003
   AllowDropFiles = True
   Caption = 'RTFP Desktop'
@@ -1006,15 +1006,15 @@ object FormDesktop: TFormDesktop
     OnChange = PageControl_NodeChange
     object TabSheet_Node_PDF: TTabSheet
       Caption = 'PDF预览'
-      ClientHeight = 163
-      ClientWidth = 758
+      ClientHeight = 152
+      ClientWidth = 789
       object Image_PDF_View: TImage
         AnchorSideLeft.Control = TabSheet_Node_PDF
         AnchorSideTop.Control = TabSheet_Node_PDF
         AnchorSideBottom.Control = TabSheet_Node_PDF
         AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 163
+        Height = 152
         Top = 0
         Width = 208
         Anchors = [akTop, akLeft, akBottom]

--- a/rtfp_main.pas
+++ b/rtfp_main.pas
@@ -17,7 +17,7 @@ uses
   RTFP_definition, rtfp_constants, rtfp_type, sync_timer, source_dialog;
 
 const
-  C_VERSION_NUMBER  = '0.2.3-alpha.6';
+  C_VERSION_NUMBER  = '0.2.3-alpha.7';
   C_SOFTWARE_NAME   = 'RTFP Desktop';
   C_SOFTWARE_AUTHOR = 'Apiglio';
 

--- a/rtfp_main.pas
+++ b/rtfp_main.pas
@@ -17,7 +17,7 @@ uses
   RTFP_definition, rtfp_constants, rtfp_type, sync_timer, source_dialog;
 
 const
-  C_VERSION_NUMBER  = '0.2.3-alpha.9';
+  C_VERSION_NUMBER  = '0.2.3-alpha.10';
   C_SOFTWARE_NAME   = 'RTFP Desktop';
   C_SOFTWARE_AUTHOR = 'Apiglio';
 
@@ -239,8 +239,8 @@ type
     procedure Button_MainSorterClick(Sender: TObject);
 
     procedure Button_NodeViewRecoverClick(Sender: TObject);
-    procedure Button_Project_NodeView_FreshClick(Sender: TObject);
     procedure Button_tempClick(Sender: TObject);
+    procedure CheckBox_KlassNotClick(Sender: TObject);
     procedure CheckBox_MainSorterAutoClick(Sender: TObject);
     procedure Edit_DBGridMain_SorterChange(Sender: TObject);
     procedure Edit_DBGridMain_SorterKeyDown(Sender: TObject; var Key: Word;
@@ -2271,17 +2271,14 @@ begin
   NodeViewValidate;
 end;
 
-procedure TFormDesktop.Button_Project_NodeView_FreshClick(Sender: TObject);
-begin
-  //LvlGraphControl.Clear;
-  //LvlGraphControl.Graph.GetEdge('AA','BB',true);
-  //LvlGraphControl.Graph.GetEdge('AA','CC',true);
-  //LvlGraphControl.Graph.GetEdge('AA','DD',true);
-end;
-
 procedure TFormDesktop.Button_tempClick(Sender: TObject);
 begin
   LayoutMode:=(LayoutMode+1) mod 3;
+end;
+
+procedure TFormDesktop.CheckBox_KlassNotClick(Sender: TObject);
+begin
+  CurrentRTFP.RunPerformance.Klass_Filter_NOT:=(Sender as TCheckBox).Checked;
 end;
 
 procedure TFormDesktop.CheckBox_MainSorterAutoClick(Sender: TObject);

--- a/rtfp_main.pas
+++ b/rtfp_main.pas
@@ -17,7 +17,7 @@ uses
   RTFP_definition, rtfp_constants, rtfp_type, sync_timer, source_dialog;
 
 const
-  C_VERSION_NUMBER  = '0.2.3-alpha.8';
+  C_VERSION_NUMBER  = '0.2.3-alpha.9';
   C_SOFTWARE_NAME   = 'RTFP Desktop';
   C_SOFTWARE_AUTHOR = 'Apiglio';
 
@@ -38,6 +38,7 @@ type
   TFormDesktop = class(TForm)
     AListView_Klass: TACL_ListView;
     AListView_Attrs: TACL_ListView;
+    Button_MainSorter: TButton;
     Button_FormatEditPostAndNext: TButton;
     Button_FormatEditLoad: TButton;
     Button_FormatEditPostAndPrev: TButton;
@@ -50,6 +51,12 @@ type
     Button_AddAttrs: TButton;
     Button_AddField: TButton;
     Button_AddKlass: TButton;
+    CheckBox_MainSorterAuto: TCheckBox;
+    Edit_DBGridMain_Sorter: TEdit;
+    Label_MainSorter: TLabel;
+    RadioButton_KlassAND: TRadioButton;
+    CheckBox_KlassNot: TCheckBox;
+    RadioButton_KlassOR: TRadioButton;
     CheckBox_MainFilterAuto: TCheckBox;
     Combo_FieldType: TComboBox;
     ComboBox_FormatEdit: TComboBox;
@@ -229,10 +236,17 @@ type
     procedure Button_FormatEdit_RenClick(Sender: TObject);
     procedure Button_helpClick(Sender: TObject);
     procedure Button_MainFilterClick(Sender: TObject);
+    procedure Button_MainSorterClick(Sender: TObject);
 
     procedure Button_NodeViewRecoverClick(Sender: TObject);
     procedure Button_Project_NodeView_FreshClick(Sender: TObject);
     procedure Button_tempClick(Sender: TObject);
+    procedure CheckBox_MainSorterAutoClick(Sender: TObject);
+    procedure Edit_DBGridMain_SorterChange(Sender: TObject);
+    procedure Edit_DBGridMain_SorterKeyDown(Sender: TObject; var Key: Word;
+      Shift: TShiftState);
+    procedure RadioButton_KlassANDClick(Sender: TObject);
+    procedure RadioButton_KlassORClick(Sender: TObject);
     procedure CheckBox_MainFilterAutoClick(Sender: TObject);
     //procedure CheckListBox_MainAttrFilterClickCheck(Sender: TObject);
     procedure ComboBox_AttrNameChange(Sender: TObject);
@@ -658,6 +672,9 @@ end;
 
 procedure TFormDesktop.ProjectOpenDone(Sender:TObject);
 begin
+
+  Self.Frame_AufScript1.OpenDialog.InitialDir:=CurrentRTFP.CurrentPathFull+'script';
+  Self.Frame_AufScript1.SaveDialog.InitialDir:=CurrentRTFP.CurrentPathFull+'script';
 
   //文献节点选项卡
   Self.DataSource_Main.DataSet:=CurrentRTFP.PaperDS;
@@ -1923,6 +1940,7 @@ var tmpListItem:TListItem;
 begin
   tmpListItem:=(Sender as TACL_ListView).GetItemAt(X,Y);
   Accept:=tmpListItem<>nil;
+  if Accept then (Sender as TACL_ListView).ItemIndex:=tmpListItem.Index;
 end;
 
 procedure TFormDesktop.AListView_KlassNodeChecked(Sender: TObject;
@@ -2237,6 +2255,16 @@ begin
   if FShowWaitForm then FWaitForm.Hide;
 end;
 
+procedure TFormDesktop.Button_MainSorterClick(Sender: TObject);
+begin
+  if ProjectInvalid then exit;
+  //CurrentRTFP.RebuildMainGrid;//MainGridValidate(CurrentRTFP);
+  if FShowWaitForm then FWaitForm.Show;
+  CurrentRTFP.RunPerformance.Sorter_Command:=Edit_DBGridMain_Sorter.Caption;
+  CurrentRTFP.TableSorter;
+  if FShowWaitForm then FWaitForm.Hide;
+end;
+
 procedure TFormDesktop.Button_NodeViewRecoverClick(Sender: TObject);
 begin
   if ProjectInvalid then exit;
@@ -2254,6 +2282,40 @@ end;
 procedure TFormDesktop.Button_tempClick(Sender: TObject);
 begin
   LayoutMode:=(LayoutMode+1) mod 3;
+end;
+
+procedure TFormDesktop.CheckBox_MainSorterAutoClick(Sender: TObject);
+begin
+  Self.Button_MainSorter.Enabled:=not (Sender as TCheckBox).Checked;
+  if ProjectInvalid then exit;
+  CurrentRTFP.RunPerformance.Sorter_AutoRun:=(Sender as TCheckBox).Checked;
+  if (Sender as TCheckBox).Checked then CurrentRTFP.TableSorter;
+end;
+
+procedure TFormDesktop.Edit_DBGridMain_SorterChange(Sender: TObject);
+begin
+  if ProjectInvalid then exit;
+  CurrentRTFP.RunPerformance.Sorter_Command:=(Sender as TEdit).Caption;
+  if CurrentRTFP.RunPerformance.Sorter_AutoRun then CurrentRTFP.TableSorter;//??
+end;
+
+procedure TFormDesktop.Edit_DBGridMain_SorterKeyDown(Sender: TObject;
+  var Key: Word; Shift: TShiftState);
+begin
+  if (Shift = []) and (Key=13) then
+    begin
+      Button_MainSorterClick(nil);
+    end;
+end;
+
+procedure TFormDesktop.RadioButton_KlassANDClick(Sender: TObject);
+begin
+  RadioButton_KlassOR.Checked:=not (Sender as TRadioButton).Checked;
+end;
+
+procedure TFormDesktop.RadioButton_KlassORClick(Sender: TObject);
+begin
+  RadioButton_KlassAND.Checked:=not (Sender as TRadioButton).Checked;
 end;
 
 procedure TFormDesktop.CheckBox_MainFilterAutoClick(Sender: TObject);

--- a/rtfp_main.pas
+++ b/rtfp_main.pas
@@ -7,17 +7,17 @@ unit RTFP_main;
 interface
 
 uses
-  Classes, SysUtils, db, dbf, dbf_common, memds, sqldb, mssqlconn, FileUtil,
+  Classes, SysUtils, db, dbf, memds, FileUtil,
   Forms, Controls, Graphics, Dialogs, ComCtrls, Menus, ExtCtrls, DBGrids, Grids,
   ValEdit, StdCtrls, DbCtrls, LazUTF8, SynEdit, Clipbrd, LCLType, Buttons,
   Regexpr, SynHighlighterAuf,
 
   Apiglio_Useful, AufScript_Frame, ACL_ListView, TreeListView,
 
-  RTFP_definition, rtfp_constants, rtfp_type, sync_timer, source_dialog, simpleipc, Types;
+  RTFP_definition, rtfp_constants, rtfp_type, sync_timer, source_dialog;
 
 const
-  C_VERSION_NUMBER  = '0.2.3-alpha.5';
+  C_VERSION_NUMBER  = '0.2.3-alpha.6';
   C_SOFTWARE_NAME   = 'RTFP Desktop';
   C_SOFTWARE_AUTHOR = 'Apiglio';
 


### PR DESCRIPTION
修复BUF格式的Klass文件不能读取的错误;
增加sys.fmt默认FE格式;
增加字段的选项设置和对应的FormatEdit的combo控件;
增加attrs.rec.edit_image代码从图像文件批量导入字段功能;
增加了主表拖拽到分类列表的快捷编辑方式;
新增了主表的排序功能;
修改了使用update.begin脚本时可能出现的事件触发条件混乱;
修复图片导出模式的总数问题;
避免了排序功能在没有字段时的异常;
增加了主表Ctrl+R的引用快捷键;
增加了字段选项的修改方式